### PR TITLE
English (en) language pack + English tokenizer

### DIFF
--- a/src/bm25.ts
+++ b/src/bm25.ts
@@ -2,6 +2,7 @@
  * meow-memory v2 — 检索层。
  *
  * 分词（语言分支 v0.19.0）：zh = 字符 bigram（中文稳定、零依赖）+ 英文/数字整词；
+ * en = 整词 + 停用词过滤 + Porter 词干还原（英语有屈折变化，见下方 EN 段注释）；
  * 其他语言 = ASCII 整词基线（stemming 扩展点见 prompts/README.md），语言随 promptLang。
  * 打分：标准 BM25 × 艾宾浩斯近期权重；importance≥3 或超级匹配（≥0.85×本轮
  *       最高原始分）时豁免衰减。
@@ -29,12 +30,15 @@ const ASCII = /[a-zA-Z0-9]+/g
 
 /** 切词（语言分支，v0.19.0）：
  * - promptLang === 'zh'（默认）：中文相邻 bigram（单字不成词）+ 英文/数字整词——零依赖中文适配；
+ * - promptLang === 'en'：ASCII 整词 + 停用词过滤 + Porter 词干还原（英语屈折，见 stemEn）；
  * - 其他语言：ASCII 整词基线——词形归一化/stemming 是各语言包贡献者的扩展点
  *   （就在本函数的通用路径上，见 prompts/README.md）。
  * 语言来自 promptLang config（getPromptLang 进程级动态读取，切换后下一次检索即生效）；
+ * 取主语言码（'en-US' → 'en'，'zh-CN' → 'zh'），地区后缀不影响分词分支；
  * 打分本体（BM25/艾宾浩斯/余弦）语言无关，不分支。 */
 export function tokenize(text: string): string[] {
-  const zh = getPromptLang() === 'zh'
+  const lang = getPromptLang().toLowerCase().split(/[-_]/)[0]
+  const zh = lang === 'zh'
   const out: string[] = []
   let i = 0
   const n = text.length
@@ -60,7 +64,131 @@ export function tokenize(text: string): string[] {
       i++
     }
   }
+  return lang === 'en' ? normalizeEn(out) : out
+}
+
+// ── 英语归一化（en 分支） ────────────────────────────────────────────────────
+//
+// 检索命中要求 query 与记忆条目走同一套分词，所以归一化只做在 tokenize 里，
+// 写入侧与检索侧天然一致（关键词原文照旧原样存库，只有匹配时才归一）。
+//
+// 两步，都是英语特有、中文不需要的：
+// 1. 停用词过滤：英语功能词（the/of/is…）在每条记忆里都出现，BM25 的 idf 已经压得很低，
+//    但命中链路的覆盖率分母（keywordHitScore 的 coverage）会被它们稀释，且撇号切分
+//    （"user's" → user + s）会漏出 s/t/ll 这类碎片，一并在此丢弃。
+// 2. Porter 词干还原：英语有屈折变化，caches/caching/cached 必须归到同一词干，
+//    否则用户 prompt 写复数、记忆条目写单数就永远命中不了（中文无屈折，故 zh 分支不做）。
+//    含数字的 token（2024 / v0 / sha256）跳过——词干规则只对纯字母词有意义。
+
+/** 英语停用词（含撇号切分碎片 s/t/d/ll/ve/re/m）。功能词不承载检索意义。 */
+const EN_STOPWORDS = new Set<string>([
+  'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and', 'any', 'are', 'as', 'at',
+  'be', 'because', 'been', 'before', 'being', 'below', 'between', 'both', 'but', 'by',
+  'can', 'cannot', 'could', 'd', 'did', 'do', 'does', 'doing', 'don', 'down', 'during',
+  'each', 'few', 'for', 'from', 'further', 'had', 'has', 'have', 'having', 'he', 'her', 'here', 'hers',
+  'herself', 'him', 'himself', 'his', 'how', 'i', 'if', 'in', 'into', 'is', 'it', 'its', 'itself',
+  'just', 'll', 'm', 'me', 'more', 'most', 'my', 'myself', 'no', 'nor', 'not', 'now',
+  'of', 'off', 'on', 'once', 'only', 'or', 'other', 'ought', 'our', 'ours', 'ourselves', 'out', 'over', 'own',
+  're', 's', 'same', 'she', 'should', 'so', 'some', 'such', 't', 'than', 'that', 'the', 'their', 'theirs',
+  'them', 'themselves', 'then', 'there', 'these', 'they', 'this', 'those', 'through', 'to', 'too',
+  'under', 'until', 'up', 've', 'very', 'was', 'we', 'were', 'what', 'when', 'where', 'which', 'while',
+  'who', 'whom', 'why', 'will', 'with', 'would', 'you', 'your', 'yours', 'yourself', 'yourselves',
+])
+
+/** 停用词丢弃 + 词干还原（纯字母词才还原；数字/混合 token 原样保留）。 */
+function normalizeEn(tokens: string[]): string[] {
+  const out: string[] = []
+  for (const t of tokens) {
+    if (EN_STOPWORDS.has(t)) continue
+    out.push(/^[a-z]+$/.test(t) ? stemEn(t) : t)
+  }
   return out
+}
+
+// Porter stemmer（Porter 1980 原始算法，零依赖移植）。词干只用于匹配，不入库、不展示，
+// 所以"cach"这类非词形态无所谓——两侧同函数即可命中。
+const PORTER_STEP2: Record<string, string> = {
+  ational: 'ate', tional: 'tion', enci: 'ence', anci: 'ance', izer: 'ize', bli: 'ble',
+  alli: 'al', entli: 'ent', eli: 'e', ousli: 'ous', ization: 'ize', ation: 'ate',
+  ator: 'ate', alism: 'al', iveness: 'ive', fulness: 'ful', ousness: 'ous', aliti: 'al',
+  iviti: 'ive', biliti: 'ble', logi: 'log',
+}
+const PORTER_STEP3: Record<string, string> = {
+  icate: 'ic', ative: '', alize: 'al', iciti: 'ic', ical: 'ic', ful: '', ness: '',
+}
+
+const CONS = '[^aeiou]'
+const VOW = '[aeiouy]'
+const CONS_SEQ = `${CONS}[^aeiouy]*`
+const VOW_SEQ = `${VOW}[aeiou]*`
+const MGR0 = new RegExp(`^(${CONS_SEQ})?${VOW_SEQ}${CONS_SEQ}`)
+const MEQ1 = new RegExp(`^(${CONS_SEQ})?${VOW_SEQ}${CONS_SEQ}(${VOW_SEQ})?$`)
+const MGR1 = new RegExp(`^(${CONS_SEQ})?${VOW_SEQ}${CONS_SEQ}${VOW_SEQ}${CONS_SEQ}`)
+const HAS_VOWEL = new RegExp(`^(${CONS_SEQ})?${VOW}`)
+
+/** Porter 词干还原（小写纯字母词；长度 ≤2 原样返回）。 */
+export function stemEn(word: string): string {
+  let w = word
+  if (w.length <= 2) return w
+
+  // Step 1a — 复数
+  if (/(ss|i)es$/.test(w)) w = w.replace(/(ss|i)es$/, '$1')
+  else if (/([^s])s$/.test(w)) w = w.replace(/([^s])s$/, '$1')
+
+  // Step 1b — 过去式/进行时
+  if (/eed$/.test(w)) {
+    const stem = w.slice(0, -3)
+    if (MGR0.test(stem)) w = w.slice(0, -1)
+  } else if (/(ed|ing)$/.test(w)) {
+    const stem = w.replace(/(ed|ing)$/, '')
+    if (HAS_VOWEL.test(stem)) {
+      w = stem
+      if (/(at|bl|iz)$/.test(w)) w += 'e'
+      else if (/([^aeiouylsz])\1$/.test(w)) w = w.slice(0, -1) // 双写辅音还原
+      else if (new RegExp(`^${CONS_SEQ}${VOW}[^aeiouwxy]$`).test(w)) w += 'e' // *o 条件
+    }
+  }
+
+  // Step 1c — y → i
+  if (/y$/.test(w)) {
+    const stem = w.slice(0, -1)
+    if (HAS_VOWEL.test(stem)) w = `${stem}i`
+  }
+
+  // Step 2 / 3 — 派生后缀归并
+  for (const [suffix, repl] of Object.entries(PORTER_STEP2)) {
+    if (w.endsWith(suffix)) {
+      const stem = w.slice(0, -suffix.length)
+      if (MGR0.test(stem)) w = stem + repl
+      break
+    }
+  }
+  for (const [suffix, repl] of Object.entries(PORTER_STEP3)) {
+    if (w.endsWith(suffix)) {
+      const stem = w.slice(0, -suffix.length)
+      if (MGR0.test(stem)) w = stem + repl
+      break
+    }
+  }
+
+  // Step 4 — 剥离剩余派生后缀（m>1）
+  const step4 = /(al|ance|ence|er|ic|able|ible|ant|ement|ment|ent|ou|ism|ate|iti|ous|ive|ize)$/
+  if (step4.test(w)) {
+    const stem = w.replace(step4, '')
+    if (MGR1.test(stem)) w = stem
+  } else if (/(s|t)(ion)$/.test(w)) {
+    const stem = w.replace(/(s|t)(ion)$/, '$1')
+    if (MGR1.test(stem)) w = stem
+  }
+
+  // Step 5 — 收尾 e / 双写 l
+  if (/e$/.test(w)) {
+    const stem = w.slice(0, -1)
+    if (MGR1.test(stem) || (MEQ1.test(stem) && !new RegExp(`^${CONS_SEQ}${VOW}[^aeiouwxy]$`).test(stem))) w = stem
+  }
+  if (/ll$/.test(w) && MGR1.test(w)) w = w.slice(0, -1)
+
+  return w
 }
 
 function docText(d: Doc): string {

--- a/src/db.ts
+++ b/src/db.ts
@@ -17,6 +17,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import { keyedValue } from './prompt-loader.js'
 
 export type Level = 'soul' | 'user' | 'project' | 'fact' | 'lesson' | 'topic' | 'rules'
 export type Status = 'active' | 'archived' | 'stale'
@@ -49,21 +50,44 @@ export function relativeTime(ms: number | null | undefined): string {
   return new Date(ms).toISOString().slice(0, 10)
 }
 
-/** project 字段 → 项目名列表（逗号分隔多值，兼容单值；'全局'/空 = 无具体项目）。 */
+/** 全局标记的历史真值（zh 语言包的写法）。语言包切换后老库里存的仍是它，永远认。 */
+export const GLOBAL_PROJECT_CANON = '全局'
+
+/** 当前语言包的全局标记（labels.md 的 project.global；en = "global"）。
+ *  这是模型按 prompt 写进 project 字段的字面值，所以必须随语言走——否则
+ *  英文包里模型写的 "global" 会被当成一个叫 global 的项目：全局 rules 不再
+ *  注入、项目列表里凭空多出一个项目。
+ *  取不到（实例覆盖层的 labels.md 是老版本、缺键）时回退真值：全局判定是检索
+ *  热路径的语义，不能因为一个文案文件过期就 throw 掉整条注入链路。 */
+export function globalProjectMarker(): string {
+  try {
+    return keyedValue('labels', 'project.global')
+  } catch {
+    return GLOBAL_PROJECT_CANON
+  }
+}
+
+/** 是否全局标记（认真值 + 当前语言包写法：跨语言切换后新旧条目都要认）。 */
+export function isGlobalProject(field: string | null): boolean {
+  if (field === null) return false
+  return field === GLOBAL_PROJECT_CANON || field === globalProjectMarker()
+}
+
+/** project 字段 → 项目名列表（逗号分隔多值，兼容单值；全局标记/空 = 无具体项目）。 */
 export function projectList(field: string | null): string[] {
-  if (!field || field === '全局') return []
+  if (!field || isGlobalProject(field)) return []
   return field.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
 }
 
-/** project 字段是否覆盖某项目名（多值包含判断；null/'全局' = 全局适用任何项目）。 */
+/** project 字段是否覆盖某项目名（多值包含判断；null/全局标记 = 全局适用任何项目）。 */
 export function projectCovers(field: string | null, name: string): boolean {
-  if (field === null || field === '全局') return true
+  if (field === null || isGlobalProject(field)) return true
   return projectList(field).includes(name)
 }
 
-/** project 字段的展示标签：'全局'=真全局；null/''=未标记；多值 join '/'（如 dsh/femwa）。 */
+/** project 字段的展示标签：全局标记=真全局（按当前语言显示）；null/''=未标记；多值 join '/'（如 dsh/femwa）。 */
 export function projectLabel(field: string | null): string {
-  if (field === '全局') return '全局'
+  if (isGlobalProject(field)) return globalProjectMarker()
   if (field === null || field === '') return '未标记'
   return projectList(field).join('/')
 }
@@ -370,7 +394,7 @@ export class MemoryDb {
   }
 
   /** 全部出现过（含已过时）的项目名：project/fact/lesson/topic/rules 五表的 project 列并集
-   *  （多值逗号分隔展开；"全局"是全局标记不是项目，排除）。供记忆导引列出"用户的所有 project"。 */
+   *  （多值逗号分隔展开；全局标记不是项目，projectList 已排除）。供记忆导引列出"用户的所有 project"。 */
   listProjectNames(): string[] {
     const names = new Set<string>()
     for (const level of ['project', 'fact', 'lesson', 'topic', 'rules'] as const) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -17,7 +17,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { keyedValue } from './prompt-loader.js'
+import { fillTemplate, keyedValue } from './prompt-loader.js'
 
 export type Level = 'soul' | 'user' | 'project' | 'fact' | 'lesson' | 'topic' | 'rules'
 export type Status = 'active' | 'archived' | 'stale'
@@ -39,14 +39,17 @@ export const LEVEL_LABELS: Record<Level, string> = {
   rules: '设计原则与行为准则',
 }
 
-/** 相对时间显示（"记忆时间戳"人性化）。 */
+/** 框架词（labels.md）：注入块与 memory_project 正文里的短词随语言包走。 */
+const lbl = (key: string, params?: Record<string, string>): string => fillTemplate(keyedValue('labels', key), params)
+
+/** 相对时间显示（"记忆时间戳"人性化）。文案外置：labels.md 的 time.*。 */
 export function relativeTime(ms: number | null | undefined): string {
-  if (!ms) return '无时间戳'
+  if (!ms) return lbl('time.none')
   const diff = Date.now() - ms
-  if (diff < 60_000) return '刚刚'
-  if (diff < 3600_000) return `${Math.floor(diff / 60_000)} 分钟前`
-  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)} 小时前`
-  if (diff < 30 * 86_400_000) return `${Math.floor(diff / 86_400_000)} 天前`
+  if (diff < 60_000) return lbl('time.justNow')
+  if (diff < 3600_000) return lbl('time.minutes', { n: String(Math.floor(diff / 60_000)) })
+  if (diff < 86_400_000) return lbl('time.hours', { n: String(Math.floor(diff / 3600_000)) })
+  if (diff < 30 * 86_400_000) return lbl('time.days', { n: String(Math.floor(diff / 86_400_000)) })
   return new Date(ms).toISOString().slice(0, 10)
 }
 
@@ -61,7 +64,7 @@ export const GLOBAL_PROJECT_CANON = '全局'
  *  热路径的语义，不能因为一个文案文件过期就 throw 掉整条注入链路。 */
 export function globalProjectMarker(): string {
   try {
-    return keyedValue('labels', 'project.global')
+    return lbl('project.global')
   } catch {
     return GLOBAL_PROJECT_CANON
   }
@@ -88,7 +91,7 @@ export function projectCovers(field: string | null, name: string): boolean {
 /** project 字段的展示标签：全局标记=真全局（按当前语言显示）；null/''=未标记；多值 join '/'（如 dsh/femwa）。 */
 export function projectLabel(field: string | null): string {
   if (isGlobalProject(field)) return globalProjectMarker()
-  if (field === null || field === '') return '未标记'
+  if (field === null || field === '') return lbl('project.unlabeled')
   return projectList(field).join('/')
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -17,7 +17,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { fillTemplate, keyedValue } from './prompt-loader.js'
+import { fillTemplate, getPromptLang, keyedValue } from './prompt-loader.js'
 
 export type Level = 'soul' | 'user' | 'project' | 'fact' | 'lesson' | 'topic' | 'rules'
 export type Status = 'active' | 'archived' | 'stale'
@@ -56,6 +56,12 @@ export function relativeTime(ms: number | null | undefined): string {
 /** 全局标记的历史真值（zh 语言包的写法）。语言包切换后老库里存的仍是它，永远认。 */
 export const GLOBAL_PROJECT_CANON = '全局'
 
+/** 语言 → 全局标记的进程级缓存。此值走 projectCovers/projectList，命中链路每条
+ *  用户消息都要按它过滤整库（几百条），逐条读文件解析会把热路径拖到 10ms 量级——
+ *  这一个键按语言缓存（切语言即失效）。代价：改 labels.md 的 project.global 需要
+ *  切一次语言或重启才生效；它是语义标记不是可随手改的文案，这个取舍是划算的。 */
+let markerCache: { lang: string; marker: string } | null = null
+
 /** 当前语言包的全局标记（labels.md 的 project.global；en = "global"）。
  *  这是模型按 prompt 写进 project 字段的字面值，所以必须随语言走——否则
  *  英文包里模型写的 "global" 会被当成一个叫 global 的项目：全局 rules 不再
@@ -63,17 +69,26 @@ export const GLOBAL_PROJECT_CANON = '全局'
  *  取不到（实例覆盖层的 labels.md 是老版本、缺键）时回退真值：全局判定是检索
  *  热路径的语义，不能因为一个文案文件过期就 throw 掉整条注入链路。 */
 export function globalProjectMarker(): string {
+  const lang = getPromptLang()
+  if (markerCache !== null && markerCache.lang === lang) return markerCache.marker
+  let marker: string
   try {
-    return lbl('project.global')
+    marker = lbl('project.global')
   } catch {
-    return GLOBAL_PROJECT_CANON
+    marker = GLOBAL_PROJECT_CANON
   }
+  markerCache = { lang, marker }
+  return marker
 }
 
-/** 是否全局标记（认真值 + 当前语言包写法：跨语言切换后新旧条目都要认）。 */
+/** 是否全局标记（认真值 + 当前语言包写法：跨语言切换后新旧条目都要认）。
+ *  容忍首尾空白与大小写：模型照 prompt 写字面值，英文里 "Global"/"global " 都会出现，
+ *  漏认一次就是一条本该全局的记忆退化成一个假项目——宁可宽。 */
 export function isGlobalProject(field: string | null): boolean {
   if (field === null) return false
-  return field === GLOBAL_PROJECT_CANON || field === globalProjectMarker()
+  const trimmed = field.trim()
+  if (trimmed === GLOBAL_PROJECT_CANON) return true
+  return trimmed.toLowerCase() === globalProjectMarker().toLowerCase()
 }
 
 /** project 字段 → 项目名列表（逗号分隔多值，兼容单值；全局标记/空 = 无具体项目）。 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -770,7 +770,7 @@ function persistWindowIndex(): void {
 // re-export 供测试/调试/其他插件
 export { PLUGIN_SOURCE, REFLECT_MARKER }
 export { collectDreamStates } from './dream-signal.js'
-export { MemoryDb, memoryDbPath, getDb, closeAllDbs, LEVELS, newId, PROJECT_SUBCATEGORIES, projectList, projectCovers, projectLabel } from './db.js'
+export { MemoryDb, memoryDbPath, getDb, closeAllDbs, LEVELS, newId, PROJECT_SUBCATEGORIES, projectList, projectCovers, projectLabel, isGlobalProject, globalProjectMarker, GLOBAL_PROJECT_CANON } from './db.js'
 export { migrateLegacy } from './migrate.js'
 export { buildHitInjection, buildInjection, readSeen, markSearched, markAccessed, readInjected, markInjected, sessionsFile, getCurrentProject, setCurrentProject, releaseSeen } from './inject.js'
 export { buildReflectMessage, consecutiveToolSteps, scanTurn } from './reflect.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -770,7 +770,7 @@ function persistWindowIndex(): void {
 // re-export 供测试/调试/其他插件
 export { PLUGIN_SOURCE, REFLECT_MARKER }
 export { collectDreamStates } from './dream-signal.js'
-export { MemoryDb, memoryDbPath, getDb, closeAllDbs, LEVELS, newId, PROJECT_SUBCATEGORIES, projectList, projectCovers, projectLabel, isGlobalProject, globalProjectMarker, GLOBAL_PROJECT_CANON } from './db.js'
+export { MemoryDb, memoryDbPath, getDb, closeAllDbs, LEVELS, newId, PROJECT_SUBCATEGORIES, projectList, projectCovers, projectLabel, relativeTime, isGlobalProject, globalProjectMarker, GLOBAL_PROJECT_CANON } from './db.js'
 export { migrateLegacy } from './migrate.js'
 export { buildHitInjection, buildInjection, readSeen, markSearched, markAccessed, readInjected, markInjected, sessionsFile, getCurrentProject, setCurrentProject, releaseSeen } from './inject.js'
 export { buildReflectMessage, consecutiveToolSteps, scanTurn } from './reflect.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -774,6 +774,6 @@ export { MemoryDb, memoryDbPath, getDb, closeAllDbs, LEVELS, newId, PROJECT_SUBC
 export { migrateLegacy } from './migrate.js'
 export { buildHitInjection, buildInjection, readSeen, markSearched, markAccessed, readInjected, markInjected, sessionsFile, getCurrentProject, setCurrentProject, releaseSeen } from './inject.js'
 export { buildReflectMessage, consecutiveToolSteps, scanTurn } from './reflect.js'
-export { tokenize, search, findSimilar, topicDrift, recencyWeight } from './bm25.js'
+export { tokenize, stemEn, search, findSimilar, topicDrift, recencyWeight } from './bm25.js'
 export { fillTemplate, keyedValue, resolveSlotText, setPromptLang, getPromptLang, DEFAULT_LANG, SLOTS } from './prompt-loader.js'
 export { collectDreamRounds, buildDreamMessage, windowNeedsDream, DREAM_MARKER, noteActivity, hourInTimeZone, minutesInTimeZone, isDreamSuppressed, startWindowDream, advanceDream, abortDream, recoverInterruptedDream, dreamCommandDefinition } from './dream.js'

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -13,7 +13,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import type { Doc } from './bm25.js'
 import { keywordHitScore, search, tokenize } from './bm25.js'
-import { projectCovers, projectLabel, relativeTime, type MemoryDb, type MemoryRow } from './db.js'
+import { isGlobalProject, projectCovers, projectLabel, relativeTime, type MemoryDb, type MemoryRow } from './db.js'
 import { fillTemplate, keyedValue } from './prompt-loader.js'
 
 export interface InjectOptions {
@@ -227,7 +227,7 @@ function hitQuery(
     ...db.list('rules', { status: 'active' }),
     ...db.list('topic', { status: 'active' }),
   ].filter((r) =>
-    (r.project === null || r.project === '全局' || (currentProject !== null && projectCovers(r.project, currentProject)))
+    (r.project === null || isGlobalProject(r.project) || (currentProject !== null && projectCovers(r.project, currentProject)))
     && r.source_session !== sessionId, // 本 session 建立的记忆在上下文里，不命中
   )
   if (hitRows.length === 0) return []

--- a/src/prompts/README.md
+++ b/src/prompts/README.md
@@ -48,7 +48,17 @@ src/prompts/
 
 ## One more thing: the tokenizer / 分词器也是语言分支
 
-`src/bm25.ts` → `tokenize()` branches on the same language: `zh` uses character bigrams (Chinese has no spaces); **every other language currently falls back to an ASCII word baseline** with no normalization. If your language needs stemming / lemmatization / its own segmentation, that function is yours to extend — PRs welcome. Keyword recall depends on query and memory entries being tokenized the same way, so this matters as much as the translations themselves.
+`src/bm25.ts` → `tokenize()` branches on the same language (on its base code, so `en-US` → `en`, `zh-CN` → `zh`):
+
+| lang | tokenizer |
+|---|---|
+| `zh` | character bigrams (Chinese has no spaces) + whole ASCII words |
+| `en` | whole words, lowercased → stopwords dropped → Porter stemmer (`stemEn`) |
+| anything else | **ASCII word baseline**, no normalization |
+
+If your language needs stemming / lemmatization / its own segmentation, that function is yours to extend — PRs welcome. Keyword recall depends on query and memory entries being tokenized the same way, so this matters as much as the translations themselves.
+
+Normalization lives **only** in `tokenize()`, so both sides of a match go through it and stay consistent; keywords are still stored verbatim, they are only normalized at match time. Anything language-specific you add belongs there too.
 
 ## Config / 用户配置
 

--- a/src/prompts/README.md
+++ b/src/prompts/README.md
@@ -25,12 +25,13 @@ src/prompts/
 | `dream-topic.md` | whole text | `{list}` |
 | `dream-project-summary.md` | whole text | `{projects}` |
 | `welcome-guide.md` | whole text | `{homePath}` |
-| `labels.md` | key-value lines | per key（e.g. `{label}` `{name}` `{list}`） |
+| `labels.md` | key-value lines | per key（e.g. `{label}` `{name}` `{list}` `{n}`） |
 | `tools.md` | key-value lines | — |
 
 - **`zh/` is the key-set source of truth**: every slot & key in `zh` must exist in your language — no missing, no extras.
 - **Whole-text slots**: translate freely; keep `{placeholders}` and place them where your grammar needs them.
 - **Key-value slots**: lines shaped `- key: value` — keep **keys exactly as-is** (the code looks them up), translate **values** only. A line starting with two spaces continues the previous value.
+- One value in `labels.md` is **not** decoration: `project.global` is the word the model writes into a memory's `project` field for globally applicable information, and the code matches on it. Pick a natural word in your language, keep it to one word, and don't reuse it as a real project name.
 - Lines starting with `#` are comments; blank lines are ignored.
 
 ## Resolution order / 读取顺序（per slot, 逐槽位）

--- a/src/prompts/en/dream-atomic.md
+++ b/src/prompts/en/dream-atomic.md
@@ -1,0 +1,29 @@
+[Entries in this group]: {list}
+
+The [Entries in this group] list above is the entire scope of this round: the entries you created yourself, plus the ones you saw in this window through injection, search, or memory_read. That is where the scope ends — don't try to recall entries you "saw but that aren't listed".
+Is there anything here you think should be tidied up or updated? If so, update it.
+
+## How to decide something needs updating — go through the list above entry by entry and ask yourself:
+1. Was anything recorded wrongly or one-sidedly, has it gone out of date, does it need new information, did the user change their mind, has there been new progress? -> Update the content promptly; the memory store should match the project's latest state.
+2. Was any design or piece of information overturned, changed, or proven not to work? -> Set status=archived. Never leave those active or stale. stale only means "finished" (a todo done, a topic that reached its goal), not "void"; superseded approaches and conclusions left in the store will only mislead later sessions.
+3. Are there completed todo entries? -> Set status=stale (which means done);
+4. Are there entries that are wrong, too trivial, or that you now think don't matter at all? -> Set status=archived;
+5. Have bugs been fixed, or lessons stopped applying? -> Change the content, or set status=archived;
+6. Did you find entries that contradict each other? -> Fix them according to what you know to be true. Keep the newest fact, archive the older version;
+7. Looking back now, is each entry's importance right (check it against the memory system's importance rules)? Note: don't mark things important lightly — work-in-progress entries are usually 1, at most 2; only something serious deserves 3. Where it is inflated, lower it;
+8. Is any entry too long, carrying too much? -> Split it into several, using update to rewrite and remember to create the new ones.
+9. Are the keywords accurate? -> If they are, leave the keywords parameter out; if you think they are off, fix them with memory_update's keywords parameter — when the user's prompt hits an entry's keywords, that entry gets pulled in. So think backwards: "which words in a user prompt should make this memory surface?" That is your standard. Don't use the project name as a keyword; use words specific to the entry. Prefer core entities, the semantic center, proper nouns. Plain dictionary form — the tokenizer stems English words, so a singular already matches its plural, and stopwords retrieve nothing. 8-13 of them.
+10. Are the project labels right? Is anything labeled with a project when it is really global information? Then the project label should go. Does anything clearly belong to a project but carry no project information? Then add it.
+11. Learning without reflection is wasted — generalize more:
+- This is an excellent moment to abstract and consolidate. Are there general rules worth distilling? Add them as new memories.
+- You may now understand some entries better and more deeply than when you wrote them. Update them.
+12. Look at what gets injected on the first turn. Do you still think all of it matters? Does it really need to be injected at the start of every session? Anything that doesn't, you can lower in importance or move to another level (fact, for instance).
+The first turn injects only: soul (the AI itself) / user (the user's preferences) / global rules (importance>=2). To get something into the first turn: a global rule -> move it to rules with importance>=2 (project "global"); something about the user -> move it to user; something about you -> move it to soul.
+13. memory_project shows project-level entries (completed todos, only the 5 most recent) plus project-specific rules; the checks above apply there too (completed todos go stale, out-of-date entries go archived, project labels stay accurate).
+
+Notes:
+Important: go through them one by one, and archive or fix memories that are out of date or that mislead you — prefer archiving.
+For a memory you consider very important, if you are unsure what the truth is, go read the project's files and check. Only for memories that really matter.
+When you are finished, reply "this group is consolidated" and call no other tools.
+
+You can call several tools in one turn — please finish every tool call for this task in a single response.

--- a/src/prompts/en/dream-header.md
+++ b/src/prompts/en/dream-header.md
@@ -1,0 +1,9 @@
+Memories from this window were sealed at: {timestamp}
+If another window has made progress after that timestamp, you have no way of knowing. So when a memory conflicts with what you know from context, use the timestamp to work out which it is — the memory being wrong, or you being behind — before deciding whether to change it.
+
+Timestamp rules:
+Every timestamp shown to you is that memory's **last updated** timestamp.
+Because what you are looking at now is a very long stretch of context, a relative timestamp like "3 hours ago" keeps shifting and isn't worth relying on. Read the absolute timestamp to judge how old a memory is.
+
+
+Group {idx}/{total} - {roundKind}

--- a/src/prompts/en/dream-project-summary.md
+++ b/src/prompts/en/dream-project-summary.md
@@ -1,0 +1,12 @@
+For the projects you have been working on, call memory_project again, take another look at how memory describes them, and then condense it.
+Projects in this group: {projects}
+
+# How to summarize a project
+1. What memory_project returns may be too wordy. If it really is bloated, you must condense it into new, tighter entries (memory_remember, level=project); if it is already lean, leave it alone.
+2. How many entries to write is your call — summarize only what genuinely matters.
+3. Understand the stakes: your summary becomes this project's long-term memory. Whenever another window works on this project, this is the first thing it sees. So write something that will actually guide them — enough to grasp quickly what the user wants, what the project is for, what it looks like overall, and which parts of the architecture and design thinking matter.
+4. Still write entry by entry, one point per entry; pick the right subcategory for each (overview=the big picture / structure=architecture / decisions=design decisions / ops=deployment and data / todo=outstanding), 8-13 keywords, and don't inflate importance.
+5. Once you are done, archive the old entries that memory_project returned and that your new summary has replaced (memory_update with status=archived) — don't leave two descriptions of the same thing side by side. Entries your summary does not cover and that still stand on their own (an unfinished todo, a distinctive lesson) stay put; don't archive for the sake of archiving.
+6. When you are finished, reply "this group is consolidated" and call no other tools.
+
+You can call several tools in one turn — please finish every tool call for this task in a single response.

--- a/src/prompts/en/dream-topic.md
+++ b/src/prompts/en/dream-topic.md
@@ -1,0 +1,22 @@
+topic is a special kind of memory: it tracks what caused something, how it developed, and where it ended up, giving the AI the wider view of how events unfolded.
+One topic covers the arc of one thing, and the information must stay focused on that one thing — no drifting.
+If a topic's chain of events gets too long or too detailed, you can split it into smaller events.
+If you find several topic entries describing the same thing, merge them.
+If you find topics in a mess — the cause of something in topic A, its outcome in topic B, while A and B each carry other unrelated material — think through how these things actually developed and sort them out. Break the information into the clearest, most sensible set of separate things and storylines: one topic per thing.
+
+[Entries in this group]: {list}
+
+# How to update topic memories
+1. Judge from the latest information: have the things these topics describe developed, is there important new information? Update them. You can redraft a topic to fold in the new progress, and trim old points you no longer consider important.
+2. Look back over the conversation: is there a new topic worth storing? If so, create it. If your task turned up no topic memories at all, that is very likely a new topic.
+3. Are any topics sprawling or off-track? If one covers several things and you think it should be split, break the big topic into sub-topics (create new ones).
+4. Are several topics really describing the same thing and in need of merging? Merge them.
+5. Are several topics tangled together, so that the clean split only comes from merging their information and re-dividing it? Rewrite them.
+6. When you update a topic, think backwards again: "what information am I writing this topic to provide? Will someone reading it understand how this thread actually developed?"
+7. Whenever you write or change a topic, summarize its keywords too (8-13 content words for retrieval; "which words should make the AI see this memory when the user mentions them?").
+8. Record the project (a project name, or global) and the importance.
+9. For a topic you consider very important, if you are unsure what the truth is, go read the project's files and check. Only for memories that really matter.
+10. Important: check these topics for anything out of date, overturned, proven wrong, or misleading — archive it (status=archived) or rewrite it (prefer archiving). Never leave that active. And don't inflate importance: ordinary progress on a thread is 1, at most 2; only something serious deserves 3.
+11. When you are finished, reply "this group is consolidated" and call no other tools.
+
+You can call several tools in one turn — please finish every tool call for this task in a single response.

--- a/src/prompts/en/labels.md
+++ b/src/prompts/en/labels.md
@@ -23,3 +23,24 @@
 - dream.row.keywordsLabel: keywords:
 - dream.row.none: (none)
 - dream.topic.empty: (no topic memories in this group yet — look back over the conversation, and if there is a new topic, create it following guideline 2 below)
+- project.unlabeled: unlabeled
+- project.header: [project: {name}]
+- project.empty: [project: {name}] No memory entries for this project yet.
+- project.section.overview: Overview
+- project.section.structure: Structure
+- project.section.decisions: Technical decisions
+- project.section.quotes: The user's own words
+- project.section.ops: Deployment and data
+- project.section.todo: Project progress
+- project.todoDone: Done:
+- project.todoOpen: To do list:
+- time.none: no timestamp
+- time.justNow: just now
+- time.minutes: {n} min ago
+- time.hours: {n} h ago
+- time.days: {n} d ago
+- reflect.noProjects: (none yet)
+- remember.error.content: memory_remember: content is required — add what you want remembered and try again
+- remember.error.project: memory_remember: project is required — use "{global}" for globally applicable information, or the project name (comma-separate several projects) — add it and try again
+- remember.error.keywords: memory_remember: keywords is required — give 8-13 content keywords for retrieval (don't use the project name as a keyword) — add them and try again
+- remember.error.importance: memory_remember: importance is required — rate it: 4=fatal red line / health and safety, 3=stressed by the user / globally applicable, 2=a user decision or abstract conclusion, 1=trivia — add it and try again

--- a/src/prompts/en/labels.md
+++ b/src/prompts/en/labels.md
@@ -11,6 +11,7 @@
 - inject.guideSearchLine: Use memory_search when you need something (query is required, never search empty) and memory_read to read an entry in full.
 - inject.guideProjectLine: When a task involves a project, start with memory_project for the project-wide picture (pass the project name, it cannot be empty) — that is how you get a whole-project understanding.
 - inject.guideProjects: All of the user's projects: {list}
+- project.global: global
 - inject.hitHeader: Possibly relevant memories, for reference only:
 - dream.title: Memory consolidation task (dream)
 - dream.round.atomic: atomic memory entries

--- a/src/prompts/en/labels.md
+++ b/src/prompts/en/labels.md
@@ -1,0 +1,24 @@
+# meow-memory short framework words (key-value lines: `- key: value`; the first ASCII colon+space is the separator, the value is kept verbatim; a line starting with two spaces continues the previous value; {name} placeholders are filled in by the code. This comment line and blank lines are ignored by the parser.)
+
+- inject.title: ===== LONG-TERM MEMORY =====
+- inject.end: ===== END OF LONG-TERM MEMORY =====
+- inject.promptLabel: This turn's user prompt:
+- inject.sectionFormat: [{label}]
+- inject.aboutYou: About you
+- inject.aboutUser: About the user
+- inject.rules: Design principles
+- inject.guide: Memory guide
+- inject.guideSearchLine: Use memory_search when you need something (query is required, never search empty) and memory_read to read an entry in full.
+- inject.guideProjectLine: When a task involves a project, start with memory_project for the project-wide picture (pass the project name, it cannot be empty) — that is how you get a whole-project understanding.
+- inject.guideProjects: All of the user's projects: {list}
+- inject.hitHeader: Possibly relevant memories, for reference only:
+- dream.title: Memory consolidation task (dream)
+- dream.round.atomic: atomic memory entries
+- dream.round.topic: topic memory entries
+- dream.round.project-summary: project summary
+- dream.listHeader: [Entries in this group]:
+- dream.groupHeader: [project: {name}]
+- dream.groupUnlabeled: no project - global information, or missing a project label
+- dream.row.keywordsLabel: keywords:
+- dream.row.none: (none)
+- dream.topic.empty: (no topic memories in this group yet — look back over the conversation, and if there is a new topic, create it following guideline 2 below)

--- a/src/prompts/en/reflect.md
+++ b/src/prompts/en/reflect.md
@@ -1,0 +1,32 @@
+Memory reflection task
+Look back over your chat history.
+
+[1] Since the last [Memory reflection task], across all those turns, is there anything new worth remembering across sessions? Use memory_remember to add it.
+1. Projects already in the memory store: {projectList}. Do you think a new project should be added? -> Add a memory for the new project.
+2. Did you misremember, misspeak, or get something wrong — were you corrected by the user?
+- Anything the user corrected must be recorded, at whichever level fits (project, rules, fact, ...).
+- If you write it at the lesson level, keep the corrected flag;
+3. Add entries at your discretion when any of these apply:
+- Did the user state a communication / working / coding preference? -> Global preferences go in user; project-specific ones go in project.
+- Did the user lay down a design principle or a rule of behavior? -> Record it in rules.
+- Did the user say anything while explaining the project's design thinking, framework, or reasoning? -> Preserve their own words, at the right level.
+- Any important facts, conclusions, or decisions?
+- Did you fall into a trap while working, or need several attempts before something worked? If you think it is worth keeping, record it as a lesson.
+
+[2] Look back at every memory injected into this context, weigh it against your latest progress, and decide: does anything need updating?
+1. Is there an entry you are now certain is out of date (the user said so themselves, or changed their mind)? -> Update its content; don't leave it sitting there.
+2. Did you find an entry that is wrong, or that actively misled you? -> Correct it, or mark it archived (which means delete);
+3. Have any todos or topics been completed? -> Mark them stale (which means done);
+4. Did an entry get injected at a completely unreasonable moment, with no bearing on the task at hand? -> That means its keywords are off; update them;
+
+[3] General requirements when writing memories
+1. The rules for writing memories are in the system prompt. Put each memory at the right level and under the right label.
+2. Worth repeating, the standard for keywords:
+- Extract 8-13 keywords for retrieval
+- Think backwards: "which words in a user prompt should make this memory surface?"
+- Not the project name — details specific to the memory itself.
+- Prefer core entities, the semantic center, proper nouns.
+- Plain dictionary form: the tokenizer stems English words, so a singular noun already matches its plural; skip stopwords, they retrieve nothing.
+3. If you think there is nothing important and nothing to add or update, just reply "no memory needed" and call no tools at all.
+
+You can call several tools in one turn — please finish every tool call for this task in a single response.

--- a/src/prompts/en/system-guide.md
+++ b/src/prompts/en/system-guide.md
@@ -1,0 +1,120 @@
+[Memory system] meow-memory gives you cross-session memory.
+
+I. What the memory store holds
+1. Memory levels:
+- soul = about you, the AI;
+- user = the user's basic facts, baseline preferences, important device/network environment, things that matter about the user themselves. Injected every session, so keep it lean — only what really matters.
+- rules = design principles / behavioral guidelines. Global rules take project "global"; project-specific rules take that project's name;
+- fact = small atomic facts (one plain sentence, ≤30 words);
+- lesson = mistakes and lessons, traps you fell into, things you learned by doing;
+- topic = a thread: what caused something, how it developed, where it stands. Gives you the wider view of how events unfolded. Update it as the story moves on.
+- project = a project. Project memories have subcategories:
+  overview: the project's purpose, summary, meta information, general introduction.
+  structure: anything about the project's architecture.
+  decisions: important design decisions.
+  quotes: the user's own words, when you judge them important.
+  ops: deployment and data (ports / paths / how to start it / where the database lives / operational steps).
+  todo: your and the user's to-do list — tasks you think are coming up.
+
+2. Structure and requirements:
+- Memories are stored as separate entries in a database. No entry should be too long (topic entries excepted).
+- Each entry should be about one thing or one fact. If there are many facts, split them into several entries.
+- Every entry must have keywords.
+- topic entries are a special case: they may run longer, but they still stay on one thread — never mix several storylines into one.
+- If you notice an entry carrying too much, split it up on your own initiative.
+- Memories must stay current. When a fact or a project's state changes, update the content or change the entry's status promptly.
+
+3. How memories reach you
+- Relevant memories are injected automatically (long-term memory on the first turn + keyword hits on every message). You don't have to do anything;
+- Injected memories are for reference only:
+   They may or may not be relevant to the task at hand — if an injection has nothing to do with the current topic, its keywords are usually off, so update them.
+   They may be accurate, stale, or plain wrong — if you find an entry that is incomplete, contradicts reality, or is out of date, update it.
+- Memories are ordered by "last updated" timestamp. On conflict the newest wins; older ones can still be read as history.
+
+
+II. The memory tools you have
+
+[Writing memory]
+
+1. Add a new memory: memory_remember
+- Required: content / project / keywords (8-13 retrieval keywords) / importance.
+- If it heavily overlaps an existing entry, merge with update instead of adding a new one.
+- If an existing entry is overloaded and needs splitting, memory_remember the pieces.
+
+2. Update an existing entry: memory_update
+- Requires the memory id so it points at exactly one entry.
+- If keywords/content/project/importance/status look wrong, update them with the matching parameter.
+- One update call can change several fields at once.
+- Pass only what you want to change; leave the rest out.
+
+[Reading memory]
+
+3. See a whole project: memory_project
+- Which project do you want to look at? The project name is required.
+- Gives you the project-wide picture so you can get up to speed fast.
+- Includes design history, technical decisions, the user's own words, project progress.
+
+4. Search memory: memory_search
+- query is required: pass keywords or a sentence (e.g. "memory plugin deployment"). Never search with an empty query.
+- Returns a metadata view, not full text; use the keywords to judge which entry holds what you need, then read the full entry with memory_read.
+- Default top 10 = the first 5 purely by relevance (nothing excluded, including entries already injected/searched/created this session) + 5 more that skip already-injected/already-searched entries.
+- Searches fact/lesson/topic/rules by default;
+- You can restrict it to a level/project/status (multi-select, comma-separated).
+- You can restrict by time, e.g. days: 30 = only entries created in the last 30 days.
+- Default top k = 10; k can be 1-50.
+
+5. Read a single entry: memory_read
+- Reads the full content by memory id (including keywords/importance/status metadata).
+
+6. Find duplicates and conflicts: memory_find_similar
+- Finds entries similar to a given memory id.
+
+7. Searchable source files
+- Memories live in SQLite (the path is printed at the end of memory_project's output); when memory_search is not enough you can query the database directly.
+- When the memory store has nothing, search the raw chat logs.
+  Raw chat logs: $DSH_HOME/sessions/<workspace>/<session id>/session.jsonl.zstd — Zstandard-compressed JSONL;
+  one-liner with node:zlib on Node >= 22.13:
+  node -e "console.log(require('node:zlib').zstdDecompressSync(require('fs').readFileSync(process.argv[1])).toString())" <file>
+- In particular, when the user asks about a detail that memory search cannot find, take the user's description plus whatever related clues you did find and go search the raw chat logs.
+
+[Consolidating memory]
+
+8. Consolidate this window's memories: memory_dream
+- Triggers automatically after 3+ hours of window idle time (suppressed during peak hours, 09:00-12:00 and 14:00-18:00 Beijing time, plus the 15 minutes before each). You can also call it by hand.
+
+
+III. Writing standards (they apply to both new and updated memories):
+1. content
+- Keep it short. If it runs long, split it into several entries.
+- High information density, no padding.
+- When the user describes a project, preserve their own wording wherever you can — their phrasing carries their reasoning, and that is valuable.
+- Keep it current. The moment you find something wrong or out of date, fix the content or archive the entry. Never leave a wrong or stale memory in active status.
+
+2. keywords
+- Understand what keywords are for: the memory system retrieves on them. When the user's prompt hits an entry's keywords, that entry gets pulled in.
+- So think backwards: "which words in a user prompt should make this memory surface?" That is your standard for writing keywords.
+- Extract 8-13 keywords per entry.
+- Don't use the project name as a keyword; use words specific to this entry.
+- Prefer core entities, the semantic center, proper nouns.
+- Write keywords in their plain dictionary form — the tokenizer stems English words (running/ran -> run, caches -> cach), so a singular noun already matches its plural. Don't burn slots on both forms; spend them on distinct concepts instead.
+- Skip stopwords (the, and, is, with, ...) — the tokenizer drops them, so they retrieve nothing.
+- If an entry is being injected at the wrong moment, with no bearing on what you are discussing, its keywords are poorly chosen. Update them.
+
+3. importance
+- Critical, dangerous, get-it-wrong-and-it-hurts decisions / red lines / lessons, and anything about health or safety -> 4;
+- Things the user stressed, things the user considers important, globally applicable rules, globally applicable general information -> 3;
+- User decisions, abstract conclusions spanning several files and hard to verify -> 2;
+- Trivial atomic details, narrowly applicable information, small notes worth jotting down -> 1.
+
+4. status
+- New memories default to active. memory_update changes status.
+- stale = finished (a completed todo -> stale means done);
+- archived = deleted (out of date, void, duplicated, superseded by a newer version);
+- Otherwise leave it active.
+
+5. project
+- If the user starts telling you about a brand-new project, create that project.
+- If the information applies to one specific project, write that project's name when you remember it.
+- If it applies globally, not to any single project, set project to "global".
+- If it isn't global but does apply to several projects, list the project names separated by commas (e.g. "dsh, femwa").
+- If an entry's project field is wrong or incomplete, update it.

--- a/src/prompts/en/tools.md
+++ b/src/prompts/en/tools.md
@@ -1,0 +1,66 @@
+# meow-memory tool copy (key-value lines: `- key: value`; the first ASCII colon+space is the separator, the value is kept verbatim; a line starting with two spaces continues the previous value. `###` headings are for readers only and are ignored by the parser.
+# Key convention: <tool>.description / <tool>.param.<name> / <tool>.out.<path>. A missing key throws; new keys must be mirrored in src/tools.ts.)
+
+### memory_remember
+
+- memory_remember.description: Write something worth remembering across sessions into this workspace's memory store (SQLite, one table per level). Required: content / project ("global", or a project name; comma-separate several) / keywords (8-13 retrieval keywords) / importance. Leaving one out raises an error asking you to fill it in. Levels: soul=the AI itself (use sparingly); user=the user's basic facts and baseline preferences; project=a project (e.g. femwa/meow-memory/meow-eyes/dsh); rules=design principles / behavioral guidelines (a global rule takes project "global", and with importance>=2 it is injected in full on the first turn;  a project-specific rule takes that project's name and is injected with memory_project; everything else surfaces through search); fact=small atomic facts (one plain sentence, <=30 words); lesson=mistakes and lessons (anything you were corrected on belongs here); topic=a thread (give it a goal sentence; retrieved by keywords). Hard rule: when the user explains a project's design thinking, framework, or the reasoning behind a decision, content must preserve the user's own wording — do not paraphrase or summarize it away. Entries that heavily overlap an existing one are merged automatically (updated, not duplicated). The tool confirms on success — no need to call it again.
+- memory_remember.param.content: What to remember; fact/lesson one sentence <=30 words; topic <=180 words; wherever the user's own words are involved, keep their wording.
+- memory_remember.param.level: Memory level, default fact.
+- memory_remember.param.project: Required. Project name (must be a concrete project name when level=project); use "global" for globally applicable information; comma-separate several projects, e.g. "dsh,femwa".
+- memory_remember.param.subcategory: project subcategory: overview=purpose and summary / structure=architecture / decisions=technical decisions / quotes=the user's own words / ops=deployment and data / todo=in progress.
+- memory_remember.param.goal: The topic's goal sentence (recommended when level=topic, e.g. "get the femGen integration working").
+- memory_remember.param.importance: Importance (any number, no upper bound; soft guide 1-4: 4=fatal red line / health and safety, 3=stressed by the user / globally applicable, 2=a user decision or an abstract conclusion, 1=trivia).
+- memory_remember.param.corrected: Whether this is something the user corrected (for level=lesson).
+- memory_remember.param.keywords: Keywords you choose (the reflection/dream rounds ask for 8-13 content words; omit it and they are extracted automatically).
+- memory_remember.out.keywords: The keywords actually stored (auto-extracted; after a merge, the latest value).
+- memory_remember.out.project: The project actually recorded (if any).
+
+### memory_search
+
+- memory_search.description: Search this workspace's memory store (BM25 x recency weight). query is required and must not be empty — pass the keywords or sentence you are looking for, e.g. memory_search({query: "memory plugin deployment"}); to browse a whole project use memory_project (no query needed), don't call this tool with an empty query. What comes back (the user's call): default top 10 = the first 5 straight off the relevance ranking (nothing excluded, including entries already injected/searched/created this session) + 5 more taken from further down the ranking while skipping already-injected/already-searched entries (so you get fresh material). Default scope = fact+lesson+topic+rules; level accepts a comma-separated list (e.g. fact,lesson); pass level=project for the project-wide view. Results are taken top-k by relevance and then re-sorted by memory timestamp (old -> new), so you can see how things developed and which of two conflicting entries is newer.
+- memory_search.param.query: Search keywords or sentence (required, must not be empty; e.g. "memory plugin deployment").
+- memory_search.param.level: Restrict to levels, comma-separated: fact/lesson/topic/rules/project/soul/user (default fact,lesson,topic,rules).
+- memory_search.param.project: Filter by project name (comma-separated, OR semantics, e.g. "dsh,femwa"; "global" and unlabeled entries are always included).
+- memory_search.param.status: Filter by status (comma-separated: active/archived/stale/all; default active, where a stale todo counts as completed and still participates; including all = no filter).
+- memory_search.param.days: Only entries created in the last N days (by creation time).
+- memory_search.param.k: Maximum number of results.
+- memory_search.param.content_max: Truncate each entry's content to this length, 0=full text.
+- memory_search.out.note: Conflict note.
+- memory_search.out.hits.id: Full memory id (pass it to memory_read/memory_update/memory_find_similar).
+- memory_search.out.hits.keywords: The entry's keywords (extracted by an LLM or automatically).
+- memory_search.out.hits.project: Project the entry belongs to; ""=unlabeled; globally applicable entries read "global".
+- memory_search.out.hits.updated_at: Memory timestamp (last update, in milliseconds).
+
+### memory_find_similar
+
+- memory_find_similar.description: Find entries similar to a given memory id (cosine over term-frequency vectors) — for spotting duplicates, finding conflicts, and checking whether something close to this entry already exists. Like search, it only looks at memories created in other sessions; anything already seen in this session (injected or searched) is excluded automatically.
+- memory_find_similar.param.id: The reference memory id (the full id from memory_read/search results, or its first 12 characters).
+- memory_find_similar.param.k: Number of results.
+- memory_find_similar.param.content_max: Truncate each entry's content to this length, 0=full text.
+- memory_find_similar.out.hits.similarity: Cosine similarity 0-1; higher is closer.
+
+### memory_read
+
+- memory_read.description: Read one memory in full (including title/keywords/importance/status metadata).
+- memory_read.param.id: Memory id (from the injection block or a memory_search result).
+
+### memory_update
+
+- memory_update.description: Update a memory (content / importance / status / project / topic goal sentence / keywords, ...). status values: active / stale (finished: a completed todo, a topic that reached its goal -> stale means done) / archived (deleted: out of date, void, duplicated, or superseded entries).
+- memory_update.param.id: Memory id.
+- memory_update.param.content: New content (when rewriting a topic: cause, course, development, outcome, <=180 words).
+- memory_update.param.status: New status.
+- memory_update.param.importance: New importance (any number, no upper bound; soft guide 1-4: 4=fatal red line / health and safety, 3=stressed by the user / globally applicable, 2=a user decision or an abstract conclusion, 1=trivia).
+- memory_update.param.goal: New goal sentence (topic).
+- memory_update.param.project: New project name (project/fact/lesson/rules/topic); use "global" for globally applicable information; comma-separate several projects; an empty string clears it (unlabeled).
+- memory_update.param.keywords: Keywords you choose (fix or extend them whenever you notice they are off; omitting the parameter or passing an empty array leaves the keywords untouched).
+
+### memory_project
+
+- memory_project.description: Retrieve a project's complete injection block from the memory store (plain text, grouped by subcategory, every entry that is not out of date at once). project is required: which project do you want to see? Calling without it raises an error, so settle on the project name first. Call it when the user brings up a project (femwa/meow-memory/meow-eyes/dsh, ...) and asks about its design history, technical decisions, their own past words, or where it stands; also whenever you need the project-wide picture before you answer. Rules: within a group, entries run old -> new by memory timestamp; the todo subcategory prints "Done:" (the 5 most recently completed) followed by "To do list:"; every entry carries its full id, its last-updated timestamp, and its text.
+- memory_project.param.project: Project name (the memory guide at the start of the session lists every project the user has — pick from it).
+- memory_project.out.text: The project's memory block, grouped by subcategory (plain text).
+
+### memory_dream
+
+- memory_dream.description: Schedule a memory consolidation (dream) for this window right now: everything this window created or pulled up is sent to the main agent round by round to be tidied and put away (round 1 = atomic memories, project/fact/lesson/rules/soul/user; round 2 = topic memories; round 3 = project summary, added only when this window actually touched a project). It triggers automatically after 3+ hours of window idle time (suppressed during peak hours, 09:00-12:00 and 14:00-18:00 Beijing time, plus the 15 minutes before each); this tool is the manual trigger.

--- a/src/prompts/en/welcome-guide.md
+++ b/src/prompts/en/welcome-guide.md
@@ -1,0 +1,12 @@
+[meow-memory first-time setup]
+Congratulations! If you are seeing this message, the meow-memory plugin is configured and working. 🎉
+
+One step is left: the plugin needs to know which language the user normally speaks to you in. Memory entries must be in the same language as the BM25 tokenizer, otherwise keyword retrieval hits far less often — so getting this right matters.
+
+Please complete the setup:
+1. Work out the language — ⚠️ look only at the text of messages that genuinely came from the user; do not go by the language of the system prompt, tool descriptions, injection blocks, or any file contents, which are quite likely to be in another language and will mislead you. If you are not sure, just ask the user; don't guess.
+2. Edit the host's assembly config: under {homePath}, open the file .dsh/profiles/cordis.patch.yml (on Windows: .dsh\profiles\cordis.patch.yml), find the meow-memory entry, and add promptLang: '<language code>' under its config (e.g. 'zh' / 'en'; create the config section if the entry doesn't have one).
+3. Hot-reload the plugin so the setting takes effect: if you have the dev_reload_package tool, run it on meow-memory; if not, ask the user to reload the plugin in dsh's settings or restart dsh.
+4. When you are done, briefly tell the user which language you set memory to, and where to change it later.
+
+Until then the plugin runs in Chinese (zh); nothing else is affected.

--- a/src/prompts/zh/labels.md
+++ b/src/prompts/zh/labels.md
@@ -23,3 +23,24 @@
 - dream.row.keywordsLabel: 关键词:
 - dream.row.none: （无）
 - dream.topic.empty: （本组暂无已建立的 topic 记忆——回顾对话历史，如有新 topic 请按下方指导 2 创建）
+- project.unlabeled: 未标记
+- project.header: 【项目：{name}】
+- project.empty: 【项目：{name}】该项目暂无记忆条目。
+- project.section.overview: 项目概述
+- project.section.structure: 项目结构
+- project.section.decisions: 技术决策
+- project.section.quotes: 用户原话
+- project.section.ops: 部署与数据
+- project.section.todo: 项目进度
+- project.todoDone: 已完成：
+- project.todoOpen: To do list：
+- time.none: 无时间戳
+- time.justNow: 刚刚
+- time.minutes: {n} 分钟前
+- time.hours: {n} 小时前
+- time.days: {n} 天前
+- reflect.noProjects: （暂无）
+- remember.error.content: memory_remember: content 参数必填，请补充要记住的内容后重试
+- remember.error.project: memory_remember: project 参数必填——全局信息填"{global}"，具体项目填项目名（多个项目用英文逗号分隔），请补充后重试
+- remember.error.keywords: memory_remember: keywords 参数必填——请总结 8-13 个内容关键词供检索（不要用项目名当关键词），请补充后重试
+- remember.error.importance: memory_remember: importance 参数必填——请评估重要性：4=致命红线/健康安全，3=用户强调/全局适用，2=用户决策抽象总结，1=琐碎，请补充后重试

--- a/src/prompts/zh/labels.md
+++ b/src/prompts/zh/labels.md
@@ -11,6 +11,7 @@
 - inject.guideSearchLine: 需要时用 memory_search 检索（必须传 query 检索词，不能空查）、memory_read 读取。
 - inject.guideProjectLine: 当有项目相关任务时，应先用 memory_project 查项目全景（记得带上项目名，不能空参），这样可以对项目有整体理解。
 - inject.guideProjects: 用户的所有 project：{list}
+- project.global: 全局
 - inject.hitHeader: 可能相关的记忆，仅供参考：
 - dream.title: 记忆整理任务（dream）
 - dream.round.atomic: 原子记忆条目

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -11,7 +11,7 @@
 
 import { createUserMessage, type MessageSource } from '@deepseek-ai/dsh-llm'
 import { getDb } from './db.js'
-import { resolveSlotText } from './prompt-loader.js'
+import { keyedValue, resolveSlotText } from './prompt-loader.js'
 
 const PLUGIN_SOURCE: MessageSource = { kind: 'plugin', plugin: 'meow-memory' }
 
@@ -109,7 +109,7 @@ export function buildReflectMessage(workspace: string, turnText: string, dir = '
 
 /** project 清单展示（原 buildBasePrompt 逻辑：空清单显示占位说明）。 */
 function projectNamesText(projectNames: string[]): string {
-  return projectNames.length > 0 ? projectNames.join(' / ') : '（暂无）'
+  return projectNames.length > 0 ? projectNames.join(' / ') : keyedValue('labels', 'reflect.noProjects')
 }
 
 export { PLUGIN_SOURCE }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,7 +10,7 @@
 
 import type { ToolDefinition, ToolRunContext } from '@deepseek-ai/dsh-tools'
 import { findSimilar, search, tokenize, type RankedHit } from './bm25.js'
-import { getDb, getDreamWorkspace, memoryDbPath, projectCovers, projectLabel, projectList, relativeTime, type Level, LEVELS, type MemoryPatch, type MemoryRow, type ProjectSubcategory, PROJECT_SUBCATEGORIES } from './db.js'
+import { getDb, getDreamWorkspace, isGlobalProject, memoryDbPath, projectCovers, projectLabel, projectList, relativeTime, type Level, LEVELS, type MemoryPatch, type MemoryRow, type ProjectSubcategory, PROJECT_SUBCATEGORIES } from './db.js'
 import { keyedValue } from './prompt-loader.js'
 
 /** tools.md 键值取用（prompt 文案外置 v0.19.0）：缺键时 keyedValue throw。 */
@@ -160,7 +160,7 @@ function rememberTool(dir: string): ToolDefinition {
       const db = getDb(workspace, dir)
       const source_session = sessionIdOf(exec)
       // 锚定当前 project：带 project 参数的 memory 调用更新会话状态（命中检索用它）；"全局"与多项目（逗号分隔）不锚定。
-      if (project && project !== '全局' && !project.includes(',')) setCurrentProject(workspace, source_session ?? 'unknown', project, dir)
+      if (project && !isGlobalProject(project) && !project.includes(',')) setCurrentProject(workspace, source_session ?? 'unknown', project, dir)
 
       // 去重：同 level 找相似条目 → 合并更新
       const existing = db.list(level)
@@ -297,7 +297,7 @@ function searchTool(dir: string): ToolDefinition {
         : []
       const project = projectList.length > 0 ? projectList : null
       // 锚定当前 project（命中检索限定"全局+当前项目"）；单值才锚定，"全局"不锚定。
-      if (projectList.length === 1 && projectList[0] !== '全局') setCurrentProject(workspace, sessionId ?? 'unknown', projectList[0], dir)
+      if (projectList.length === 1 && !isGlobalProject(projectList[0])) setCurrentProject(workspace, sessionId ?? 'unknown', projectList[0], dir)
       const statusList = typeof parsed.status === 'string' && parsed.status.trim()
         ? parsed.status.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
         : []
@@ -591,7 +591,7 @@ function updateTool(dir: string): ToolDefinition {
         const cleared = parsed.project.trim() === ''
         patch.project = cleared ? null : parsed.project.trim()
         // 锚定当前 project（命中检索限定"全局+当前项目"）；"全局"、清空归属、多项目（逗号分隔）不锚定。
-        if (!cleared && patch.project !== '全局' && !String(patch.project).includes(',')) setCurrentProject(workspace, sessionId ?? 'unknown', patch.project, dir)
+        if (!cleared && !isGlobalProject(String(patch.project)) && !String(patch.project).includes(',')) setCurrentProject(workspace, sessionId ?? 'unknown', patch.project, dir)
       }
       if (Array.isArray(parsed.keywords)) {
         // 空数组 = 不更新（用户拍板：防 AI 幻觉"不想改关键词"却传 [] 把关键词全清空）。
@@ -674,7 +674,7 @@ function projectTool(dir: string): ToolDefinition {
       const db = getDb(workspace, dir)
       // 锚定当前 project：用户话题切到某项目时 AI 调 memory_project → 命中检索立即跟进；"全局"与多项目不锚定。
       const sessionId = sessionIdOf(exec)
-      if (project !== '全局' && !project.includes(',')) setCurrentProject(workspace, sessionId ?? 'unknown', project, dir)
+      if (!isGlobalProject(project) && !project.includes(',')) setCurrentProject(workspace, sessionId ?? 'unknown', project, dir)
       const rows = db.list('project', { project }).filter((r) => r.project === project)
       const active = rows.filter((r) => r.status === 'active')
       // todo 已完成：stale 且 updated_at 非空，按 updated_at 取最近 5 条（展示仍按旧→新）。

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,11 +10,13 @@
 
 import type { ToolDefinition, ToolRunContext } from '@deepseek-ai/dsh-tools'
 import { findSimilar, search, tokenize, type RankedHit } from './bm25.js'
-import { getDb, getDreamWorkspace, isGlobalProject, memoryDbPath, projectCovers, projectLabel, projectList, relativeTime, type Level, LEVELS, type MemoryPatch, type MemoryRow, type ProjectSubcategory, PROJECT_SUBCATEGORIES } from './db.js'
-import { keyedValue } from './prompt-loader.js'
+import { getDb, getDreamWorkspace, globalProjectMarker, isGlobalProject, memoryDbPath, projectCovers, projectLabel, projectList, relativeTime, type Level, LEVELS, type MemoryPatch, type MemoryRow, type ProjectSubcategory, PROJECT_SUBCATEGORIES } from './db.js'
+import { fillTemplate, keyedValue } from './prompt-loader.js'
 
 /** tools.md 键值取用（prompt 文案外置 v0.19.0）：缺键时 keyedValue throw。 */
 const T = (key: string): string => keyedValue('tools', key)
+/** 框架词/报错文案（labels.md）：与工具描述同源，随语言包走。 */
+const L = (key: string, params?: Record<string, string>): string => fillTemplate(keyedValue('labels', key), params)
 import { readSeen, markAccessed, markSearched, setCurrentProject } from './inject.js'
 
 export type { Level }
@@ -136,14 +138,14 @@ function rememberTool(dir: string): ToolDefinition {
       const parsed = args as { content?: unknown; level?: unknown; project?: unknown; subcategory?: unknown; goal?: unknown; importance?: unknown; corrected?: unknown; keywords?: unknown }
       const content = typeof parsed.content === 'string' ? parsed.content.trim() : ''
       // 四必填：缺失逐个报错并引导重填（用户拍板 2026-08-19）。
-      if (content.length === 0) throw new Error('memory_remember: content 参数必填，请补充要记住的内容后重试')
+      if (content.length === 0) throw new Error(L('remember.error.content'))
       const project = typeof parsed.project === 'string' && parsed.project.trim() ? parsed.project.trim() : null
-      if (project === null) throw new Error('memory_remember: project 参数必填——全局信息填"全局"，具体项目填项目名（多个项目用英文逗号分隔），请补充后重试')
+      if (project === null) throw new Error(L('remember.error.project', { global: globalProjectMarker() }))
       const keywords = Array.isArray(parsed.keywords)
         ? parsed.keywords.filter((k): k is string => typeof k === 'string').map((k) => k.trim()).filter((k) => k.length > 0)
         : []
-      if (keywords.length === 0) throw new Error('memory_remember: keywords 参数必填——请总结 8-13 个内容关键词供检索（不要用项目名当关键词），请补充后重试')
-      if (typeof parsed.importance !== 'number') throw new Error('memory_remember: importance 参数必填——请评估重要性：4=致命红线/健康安全，3=用户强调/全局适用，2=用户决策抽象总结，1=琐碎，请补充后重试')
+      if (keywords.length === 0) throw new Error(L('remember.error.keywords'))
+      if (typeof parsed.importance !== 'number') throw new Error(L('remember.error.importance'))
       const level: Level = typeof parsed.level === 'string' && (LEVELS as readonly string[]).includes(parsed.level)
         ? (parsed.level as Level)
         : 'fact'
@@ -610,15 +612,8 @@ function updateTool(dir: string): ToolDefinition {
   }
 }
 
-/** 子标签 → 注入段落标题。 */
-const PROJECT_SECTION_TITLES: Record<ProjectSubcategory, string> = {
-  overview: '项目概述',
-  structure: '项目结构',
-  decisions: '技术决策',
-  quotes: '用户原话',
-  ops: '部署与数据',
-  todo: '项目进度',
-}
+/** 子标签 → 注入段落标题（文案外置：labels.md 的 project.section.*）。 */
+const sectionTitle = (sub: ProjectSubcategory): string => L(`project.section.${sub}`)
 
 /** 组内排序：记忆时间戳（updated_at）旧→新，相同按创建时间；null 视为最旧。 */
 function sortByUpdatedAt(list: MemoryRow[]): MemoryRow[] {
@@ -697,34 +692,34 @@ function projectTool(dir: string): ToolDefinition {
         db.list('rules', { project }).filter((r) => r.project === project && r.status === 'active'),
       )
       if (projectRules.length > 0) {
-        sections.push(`设计原则\n${projectRules.map(fmtProjectRow).join('\n')}`)
+        sections.push(`${L('inject.rules')}\n${projectRules.map(fmtProjectRow).join('\n')}`)
       }
       for (const sub of PROJECT_SUBCATEGORIES) {
         if (sub === 'todo') {
           const todos = sortByUpdatedAt(bySub.get('todo') ?? [])
           if (todos.length === 0 && done.length === 0) continue
-          const lines = [PROJECT_SECTION_TITLES.todo]
+          const lines = [sectionTitle('todo')]
           if (done.length > 0) {
-            lines.push('已完成：')
+            lines.push(L('project.todoDone'))
             for (const r of done) lines.push(fmtProjectRow(r))
           }
           if (todos.length > 0) {
-            lines.push('To do list：')
+            lines.push(L('project.todoOpen'))
             for (const r of todos) lines.push(fmtProjectRow(r))
           }
           sections.push(lines.join('\n'))
         } else {
           const list = sortByUpdatedAt(bySub.get(sub) ?? [])
           if (list.length === 0) continue
-          sections.push(`${PROJECT_SECTION_TITLES[sub]}\n${list.map(fmtProjectRow).join('\n')}`)
+          sections.push(`${sectionTitle(sub)}\n${list.map(fmtProjectRow).join('\n')}`)
         }
       }
       if (sections.length === 0) {
-        return { project, text: `【项目：${project}】该项目暂无记忆条目。` }
+        return { project, text: L('project.empty', { name: project }) }
       }
       const dbPath = memoryDbPath(workspace, dir)
       const text = [
-        `【项目：${project}】`,
+        L('project.header', { name: project }),
         '',
         sections.join('\n\n'),
         '',

--- a/test.mjs
+++ b/test.mjs
@@ -587,6 +587,10 @@ check('global marker: en pack still recognizes legacy 全局 rows', (() => {
   setPromptLang('en')
   try { return isGlobalProject('全局') && projectCovers('全局', 'dsh') && projectLabel('全局') === 'global' } finally { setPromptLang('zh') }
 })())
+check('global marker: tolerates case and whitespace', (() => {
+  setPromptLang('en')
+  try { return isGlobalProject('Global') && isGlobalProject(' global ') && !isGlobalProject('globals') } finally { setPromptLang('zh') }
+})())
 check('global marker: en global is not a project name', (() => {
   setPromptLang('en')
   try { return projectList('global').length === 0 && projectCovers('global', 'dsh') && projectLabel('global') === 'global' } finally { setPromptLang('zh') }

--- a/test.mjs
+++ b/test.mjs
@@ -26,6 +26,9 @@ import {
   newId,
   projectCovers,
   projectLabel,
+  projectList,
+  isGlobalProject,
+  globalProjectMarker,
   collectDreamRounds,
   buildDreamMessage,
   windowNeedsDream,
@@ -572,6 +575,25 @@ check('update importance unbounded (no clamp)', up5.ok === true && db.findById(k
 check('projectCovers multi-value includes', projectCovers('dsh,femwa', 'femwa') === true && projectCovers('dsh,femwa', 'meow-eyes') === false)
 check('projectCovers global/null covers all', projectCovers('全局', 'dsh') === true && projectCovers(null, 'dsh') === true)
 check('projectLabel multi-value/global/unmarked', projectLabel('dsh,femwa') === 'dsh/femwa' && projectLabel('全局') === '全局' && projectLabel(null) === '未标记')
+
+// 全局标记随语言包（labels.md 的 project.global）：英文包里模型写的是 "global"
+check('global marker: zh pack', globalProjectMarker() === '全局' && isGlobalProject('全局') && !isGlobalProject('global'))
+check('global marker: en pack recognizes its own word', (() => {
+  setPromptLang('en')
+  try { return globalProjectMarker() === 'global' && isGlobalProject('global') } finally { setPromptLang('zh') }
+})())
+check('global marker: en pack still recognizes legacy 全局 rows', (() => {
+  setPromptLang('en')
+  try { return isGlobalProject('全局') && projectCovers('全局', 'dsh') && projectLabel('全局') === 'global' } finally { setPromptLang('zh') }
+})())
+check('global marker: en global is not a project name', (() => {
+  setPromptLang('en')
+  try { return projectList('global').length === 0 && projectCovers('global', 'dsh') && projectLabel('global') === 'global' } finally { setPromptLang('zh') }
+})())
+check('global marker: real project names untouched under en', (() => {
+  setPromptLang('en')
+  try { return projectList('dsh, femwa').join('|') === 'dsh|femwa' && !projectCovers('dsh', 'femwa') } finally { setPromptLang('zh') }
+})())
 // memory_update 刷新记忆时间戳（updated_at = 最后更新时间）
 const beforeTs = db.findById(kwId).row.updated_at
 await new Promise((r) => setTimeout(r, 5))

--- a/test.mjs
+++ b/test.mjs
@@ -29,6 +29,7 @@ import {
   projectList,
   isGlobalProject,
   globalProjectMarker,
+  relativeTime,
   collectDreamRounds,
   buildDreamMessage,
   windowNeedsDream,
@@ -593,6 +594,13 @@ check('global marker: en global is not a project name', (() => {
 check('global marker: real project names untouched under en', (() => {
   setPromptLang('en')
   try { return projectList('dsh, femwa').join('|') === 'dsh|femwa' && !projectCovers('dsh', 'femwa') } finally { setPromptLang('zh') }
+})())
+
+// 注入正文里的框架词（labels.md）：zh 输出与外置前逐字节一致，en 走英文包
+check('framework words: zh output unchanged', relativeTime(Date.now() - 5 * 60_000) === '5 分钟前' && relativeTime(null) === '无时间戳' && projectLabel(null) === '未标记')
+check('framework words: en pack renders english', (() => {
+  setPromptLang('en')
+  try { return relativeTime(Date.now() - 5 * 60_000) === '5 min ago' && relativeTime(null) === 'no timestamp' && projectLabel(null) === 'unlabeled' } finally { setPromptLang('zh') }
 })())
 // memory_update 刷新记忆时间戳（updated_at = 最后更新时间）
 const beforeTs = db.findById(kwId).row.updated_at

--- a/test.mjs
+++ b/test.mjs
@@ -747,16 +747,37 @@ check('prompt loader: reflect fills projectList', resolveSlotText('reflect', { p
 check('prompt loader: dream-atomic carries parallel-call note', resolveSlotText('dream-atomic', { list: '' }).includes('一轮可调用多个工具'))
 
 // promptLang（v0.19.0）：进程级语言状态 + BM25 分词语言分支
-import { tokenize } from './lib/index.js'
-check('prompt loader: setPromptLang switches tokenize to word baseline', (() => {
-  setPromptLang('en')
-  try { return JSON.stringify(tokenize('hello 世界 foo_bar 2024')) === JSON.stringify(['hello', 'foo', 'bar', '2024']) } finally { setPromptLang('zh') }
-})())
-check('prompt loader: zh tokenize keeps bigram', (() => {
-  setPromptLang('zh')
-  try { return JSON.stringify(tokenize('世界 hello')) === JSON.stringify(['世界', 'hello']) } finally { setPromptLang('zh') }
-})())
+import { tokenize, stemEn, search } from './lib/index.js'
+const withLang = (lang, fn) => { setPromptLang(lang); try { return fn() } finally { setPromptLang('zh') } }
+const toks = (lang, text) => withLang(lang, () => JSON.stringify(tokenize(text)))
+check('prompt loader: setPromptLang switches tokenize to word baseline', toks('ja', 'hello 世界 foo_bar 2024') === JSON.stringify(['hello', 'foo', 'bar', '2024']))
+check('prompt loader: zh tokenize keeps bigram', toks('zh', '世界 hello') === JSON.stringify(['世界', 'hello']))
 check('prompt loader: getPromptLang defaults zh', getPromptLang() === 'zh')
+
+// en 分词（语言包贡献）：停用词过滤 + Porter 词干还原
+check('en tokenize: stopwords dropped', toks('en', 'the quick brown fox') === JSON.stringify(['quick', 'brown', 'fox']))
+check('en tokenize: plural and singular collapse', toks('en', 'caches') === toks('en', 'cache'))
+check('en tokenize: inflection collapses', toks('en', 'running') === toks('en', 'run'))
+check('en tokenize: apostrophe fragment dropped', toks('en', "the user's middle name") === JSON.stringify(['user', 'middl', 'name']))
+check('en tokenize: digits and mixed tokens untouched', toks('en', 'sha256 v0.19.0 2024') === JSON.stringify(['sha256', 'v0', '19', '0', '2024']))
+check('en tokenize: all-stopword text yields nothing', toks('en', 'is it the same as that') === '[]')
+check('en tokenize: region suffix maps to base language', toks('en-US', 'caches') === toks('en', 'cache'))
+check('zh tokenize: region suffix maps to base language', toks('zh-CN', '世界') === JSON.stringify(['世界']))
+check('en tokenize: baseline languages keep raw words', toks('ja', 'the caches') === JSON.stringify(['the', 'caches']))
+check('stemEn: Porter canonical cases', [
+  ['caresses', 'caress'], ['ponies', 'poni'], ['cats', 'cat'], ['agreed', 'agre'], ['motoring', 'motor'],
+  ['hopping', 'hop'], ['filing', 'file'], ['happy', 'happi'], ['sky', 'sky'], ['relational', 'relat'],
+  ['vietnamization', 'vietnam'], ['hopefulness', 'hope'], ['electrical', 'electr'], ['adjustment', 'adjust'],
+  ['adoption', 'adopt'], ['generalizations', 'gener'], ['oscillators', 'oscil'], ['rate', 'rate'], ['roll', 'roll'],
+].every(([w, want]) => stemEn(w) === want))
+check('en retrieval: inflected query still hits the stored entry', withLang('en', () => {
+  const docs = [
+    { id: 'a', level: 'fact', title: null, content: 'BM25 keyword retrieval degrades when memories are stored in another language', keywords: ['retrieval', 'tokenizer', 'language'], importance: 1, created_at: 0, updated_at: Date.now() },
+    { id: 'b', level: 'fact', title: null, content: 'The espresso machine is descaled monthly', keywords: ['espresso', 'machine', 'descale'], importance: 1, created_at: 0, updated_at: Date.now() },
+  ]
+  const hits = search('do tokenizers matter?', docs, { k: 2 })
+  return hits.length === 1 && hits[0].id === 'a'
+}))
 
 const events = {
   userMsg: (text, source = { kind: 'user' }) => ({ type: 'user/message', data: { content: [{ type: 'text', text }], source } }),


### PR DESCRIPTION
Closes #4 — following your instructions in https://github.com/Phant0Meow/dsh-meow-memory/issues/4#issuecomment-5448800813. Thank you for turning this around so fast, and for building the language-pack system rather than just hardcoding a second language.

Five commits, each separable. The first two are what you asked for; the last three are things I ran into while doing it, and I'm happy to drop any of them if you'd rather handle them yourself.

---

### 1. `feat(prompts)` — the `en` language pack

All 9 slots translated from the `zh` source of truth. `npm run check-lang -- en` is green.

**Thresholds.** You asked me to pick the English values. What I used, and why:

| threshold | zh | en | reasoning |
|---|---|---|---|
| `fact` / `lesson` content | ≤60 characters | **≤30 words** | one plain sentence in both; ~0.5 English words per Chinese character in practice |
| `topic` content | ≤300 characters | **≤180 words** | same ratio, kept proportional |
| keywords | 8–13 | **8–13**, unchanged | keyword slots hold content words either way, and English gains nothing from more |

The keyword guidance did get two English-specific additions: write keywords in plain dictionary form (the tokenizer stems them, so a singular already matches its plural — don't spend two slots on `cache` and `caches`), and don't use stopwords as keywords, since the tokenizer drops them. These matter more in English than the count does.

If any of those numbers feel wrong to you, they're one-line edits in the pack — say the word and I'll change them.

### 2. `feat(bm25)` — English tokenizer

You were right that the file needed work. English is inflected, so under the ASCII word baseline a prompt saying "tokenizers" never matched an entry saying "tokenizer" — the memory is in the store, correctly keyworded, and simply never surfaces.

The `en` branch does:

- **stopword filter** — also catches the fragments apostrophe splitting leaves behind (`user's` → `user` + `s`)
- **Porter (1980) stemmer** — ported verbatim, zero dependencies, ~90 lines

Both sides of a match go through `tokenize()`, so queries and stored entries stay consistent; keywords are still **stored verbatim** and only normalized at match time, so nothing in the database changes.

One extra: the branch now keys off the base language code, so `en-US` → `en` and `zh-CN` → `zh`. Previously `zh-CN` silently fell through to the baseline tokenizer and lost bigrams entirely.

Other languages keep the existing baseline, untouched.

---

The next three are the ones you didn't ask for. Each one is something the English pack can't work without, or looks broken without.

### 3. `fix(i18n)` — the global-project marker

This one is a genuine blocker. `全局` isn't only prompt copy: it's a sentinel the code compares against, in `projectList` / `projectCovers` / `projectLabel`, in the hit-path scoping, and in the current-project anchoring. A pack that tells the model to write `"global"` therefore creates a project literally named *global*: global rules stop being injected on the first turn, and the memory guide starts listing "global" among the user's projects.

The marker now comes from `labels.md` (new key `project.global`, `zh` → 全局 / `en` → global) via `isGlobalProject()`, which accepts both the active pack's word and the canonical `全局` — so rows written before a language switch keep working, and `projectLabel()` renders it in the active language.

Worth noting: I'd already hit this independently when I hand-translated v0.17.0 in my own fork, and landed on the same fix there. It's not an artifact of how I wrote the pack.

### 4. `refactor(i18n)` — framework words still in code

The v0.19.0 externalization covered the prompt slots, but the short words that decorate memory entries were still string literals, so an English pack still produced injections reading:

```
[未标记 : fact] [id] 2026-08-28 10:00 [3 小时前]
```

and a `memory_project` panorama headed 项目概述 / 已完成：. That's precisely the "hard to audit by hand" complaint in the issue, so the pack doesn't really deliver without this.

17 keys moved to `labels.md` with the `zh` values copied verbatim: `relativeTime` → `time.*`, `未标记` → `project.unlabeled`, `memory_project`'s subcategory headings / todo headers / project header / empty line → `project.*`, reflect's （暂无） → `reflect.noProjects`, and `memory_remember`'s four required-parameter errors → `remember.error.*` (the project one takes `{global}` so it names the active language's marker instead of hardcoding 全局 — as written it was telling an English model to type 全局).

**`zh` rendering is byte-identical to before**, and a test asserts it.

Deliberately left in Chinese, as out of scope for this PR: the remaining tool-result and diagnostic strings in `tools.ts` / `dream.ts` (transient, never enter the memory record), and the client bundle's UI copy (`client-fold.ts` `foldLabel` and friends — browser-side, no access to the prompt loader). Happy to follow up on either if you want them.

### 5. `perf(i18n)` — cache and harden the marker

Fallout from #3 that I'd rather not leave you to find: `isGlobalProject()` sits inside `projectCovers()`, which the per-message hit path applies to every row in the store. Resolving the marker through the loader each time meant a `readFileSync` + parse per row — about **7ms on a 200-entry store**, right at your 10ms hot-path alarm and growing with the store. Cached per prompt language (invalidated by a language switch) it's ~0.004ms.

The trade-off: editing `project.global` in `labels.md` now needs a language switch or restart to take effect. It's a semantic marker rather than copy you tweak live, so that seemed the right side to err on. Every other label stays uncached and hot-reloadable.

Also hardened: the marker match tolerates surrounding whitespace and case, so a model writing `Global` doesn't quietly create a fake project. Chinese never hit this — 全局 has no case.

---

### Testing — please read, I could not run your full suite

`npm install` and `npm run build` need the `@deepseek-ai/*` workspace packages and the junction mirrors from `scripts/link-workspace.ps1`, which I don't have. **So `npm test` has not been run against these changes** — the new checks are written into `test.mjs` in your existing style and should be run on your side before you trust them.

What I did verify, by bundling the individual modules with esbuild and driving them directly:

- `npm run check-lang -- en` — green, 9 slots aligned with `zh`
- every whole-text `en` slot renders with no unfilled `{placeholder}` and no leftover CJK; all 86 `en` key-value pairs likewise
- the stemmer against **all 77 canonical examples from Porter's 1980 paper** — all pass (`test.mjs` keeps a representative 19)
- 14 tokenizer checks: stopwords, plural/singular collapse, apostrophes, digits left alone, region suffixes, other languages unaffected, and an end-to-end `search()` where the query's inflection differs from the stored entry
- 12 global-marker checks across both packs, including legacy `全局` rows under `en` and real project names staying untouched
- `zh` output of every externalized framework word, byte-for-byte against the strings they replaced
- every touched module bundles cleanly

I've left `CHANGELOG.md` and the version bump alone — those are yours to write.

Happy to rework any of this in whatever shape you prefer.
