### PR TITLE
fix: dual-version session events access — ownEvents() for dsh 0.1.2-alpha.4 with events fallback

### DIFF
--- a/src/client-fold.ts
+++ b/src/client-fold.ts
@@ -99,6 +99,9 @@ function toolNameOf(node: ChatNode): string | undefined {
  * @returns 按渲染顺序排列的折叠组。
  */
 export function computeFoldGroups(snapshot: ConversationSnapshot): FoldGroup[] {
+  // fail-closed：宿主快照形状变化（如旧/新 dsh 前端 chat 缺失）时降级为不折叠，
+  // 绝不抛错炸掉 dock（官方 issue #2 turnOf 同类无保护读教训）。
+  if (snapshot?.chat === undefined) return []
   const order = snapshot.chat.order
   const nodes = snapshot.chat.nodes
   const groups: FoldGroup[] = []
@@ -198,6 +201,7 @@ export interface InjectionGroup {
  * 旧格式继续识别含注入前缀和分隔符的 user 消息。
  */
 export function computeInjectionGroups(snapshot: ConversationSnapshot): InjectionGroup[] {
+  if (snapshot?.chat === undefined) return [] // fail-closed：快照无 chat 时不注入折叠，绝不抛错
   const groups: InjectionGroup[] = []
   for (const key of snapshot.chat.order) {
     const node = snapshot.chat.nodes.get(key)

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,21 @@ function sessionIdOfAgent(agent: { session?: { header?: SessionHeaderLike } }): 
   return typeof id === 'string' && id.length > 0 ? id : 'unknown'
 }
 
+/**
+ * 双版本会话事件读取：dsh 0.1.2-alpha.4 重构移除 Session.events 属性，
+ * 改为 ownEvents() 方法（返回剔除 fork 继承前缀的本会话事件，与旧版
+ * events 语义等价）；旧版仍是数组属性。探测函数形态优先，回退属性，
+ * 两者都缺返回空数组（fail-closed：绝不抛 events is not iterable）。
+ */
+export function sessionEventsOf(session: { events?: readonly unknown[]; ownEvents?: () => readonly unknown[] } | undefined | null): readonly unknown[] {
+  if (typeof session?.ownEvents === 'function') {
+    const evs = session.ownEvents()
+    return Array.isArray(evs) ? evs : []
+  }
+  const evs = session?.events
+  return Array.isArray(evs) ? evs : []
+}
+
 /** 本 turn 是否为 dream 轮（事件流里存在 meow-memory 的 dream 指令消息）。 */
 function wasDreamTurn(events: readonly unknown[]): boolean {
   for (let i = events.length - 1; i >= 0; i--) {
@@ -430,7 +445,7 @@ async function applyInner(ctx: Context, config: unknown): Promise<void> {
     if (!firstUserHandled.has(sid)) {
       firstUserHandled.add(sid)
       let priorUser = 0
-      for (const e of agent.session.events) {
+      for (const e of sessionEventsOf(agent.session)) {
         const evt = e as { type?: string; data?: { source?: { kind?: string } } }
         if (evt?.type === 'user/message' && evt.data?.source?.kind === 'user') priorUser++
       }
@@ -524,8 +539,8 @@ async function applyInner(ctx: Context, config: unknown): Promise<void> {
     const t0 = Date.now()
     if (agent.session.header.origin === 'subagent') return // 子代理不参与（origin 权威判定）
     registerLiveAgent(agent)
-    const endReason = lastTurnEndReason(agent.session.events)
-    const dreamTurn = wasDreamTurn(agent.session.events)
+    const endReason = lastTurnEndReason(sessionEventsOf(agent.session))
+    const dreamTurn = wasDreamTurn(sessionEventsOf(agent.session))
     const wsTs = workspaceOfAgent(agent)
     const sidTs = sessionIdOfAgent(agent)
     if (wsTs) {
@@ -547,11 +562,11 @@ async function applyInner(ctx: Context, config: unknown): Promise<void> {
     if (!resolved.reflect) return
     const ws = workspaceOfAgent(agent)
     if (!ws) return
-    const { sawToolCall, lastToolName, sawReflect, turnText } = scanTurn(agent.session.events)
+    const { sawToolCall, lastToolName, sawReflect, turnText } = scanTurn(sessionEventsOf(agent.session))
     if (sawReflect) return // 本 turn 已反思过（含反思轮自身结束）
     if (!sawToolCall) return // 纯聊天轮，不反思
     if (lastToolName !== undefined && lastToolName.startsWith('memory_')) return // 已主动记忆
-    if (consecutiveToolSteps(agent.session.events) < resolved.reflectTurns) return // 单任务内连续工具 step 不足
+    if (consecutiveToolSteps(sessionEventsOf(agent.session)) < resolved.reflectTurns) return // 单任务内连续工具 step 不足
     const message = buildReflectMessage(ws, turnText, resolved.projectDir)
     agent.steer(message)
     if (Date.now() - t0 > 20) perf(`turn-stopping slow ${Date.now() - t0}ms`)

--- a/test.mjs
+++ b/test.mjs
@@ -54,6 +54,7 @@ import {
   minutesInTimeZone,
   isDreamSuppressed,
   collectDreamStates,
+  sessionEventsOf,
 } from './lib/index.js'
 
 let passed = 0
@@ -930,6 +931,27 @@ check('resumed session skips first snapshot, hit chain inserts independent snaps
   !decisionResume.messages[0].content[0].text.includes('===== 长期记忆 =====') &&
   decisionResume.messages[1] === resumeMsg && decisionResume.messages[1].content[0].text === '测试关键词')
 
+// alpha.4 形态（Session.events 属性移除，ownEvents() 函数提供事件流）：
+// 恢复会话的快照不重复注入、命中链路照跑——与 events 数组形态行为一致。
+const alphaAgent = { session: { header: { cwd: ws, id: 'apply-session-alpha4' }, ownEvents: () => [events.userMsg('之前')] }, steer: () => {} }
+setCurrentProject(ws, 'apply-session-alpha4', 'dsh', '.dsh-meow')
+const alphaMsg = { content: [{ type: 'text', text: '测试关键词' }], source: { kind: 'user' } }
+const decisionAlpha = await preStep(
+  { agent: alphaAgent, messages: [alphaMsg], turn: 2, step: 1, signal: new AbortController().signal },
+  async () => ({ kind: 'enter', messages: [alphaMsg] }),
+)
+check('ownEvents-only session: resume skips snapshot, hit chain inserts independent snapshot', decisionAlpha.messages.length === 2 &&
+  decisionAlpha.messages[0].source.form === 'snapshot' &&
+  decisionAlpha.messages[0].content[0].text.includes('可能相关的记忆，仅供参考：') &&
+  !decisionAlpha.messages[0].content[0].text.includes('===== 长期记忆 =====') &&
+  decisionAlpha.messages[1] === alphaMsg && decisionAlpha.messages[1].content[0].text === '测试关键词')
+
+// sessionEventsOf 兼容层单元测试：ownEvents() 优先 → events 回退 → 缺失 fail-closed
+check('sessionEventsOf prefers ownEvents()', sessionEventsOf({ ownEvents: () => [1, 2], events: [9] }).length === 2)
+check('sessionEventsOf falls back to events array', sessionEventsOf({ events: [1, 2, 3] }).length === 3)
+check('sessionEventsOf fail-closed on missing both', sessionEventsOf({}).length === 0)
+check('sessionEventsOf fail-closed on undefined session', sessionEventsOf(undefined).length === 0)
+
 // 同会话第二次 pre-step（Set 命中）→ 零开销放行，不再注入（回归：防重复注入膨胀上下文）
 const decisionA2 = await preStep(
   { agent: agentA, messages: [{ content: [{ type: 'text', text: '第二条消息' }], source: { kind: 'user' } }], turn: 2, step: 1, signal: new AbortController().signal },
@@ -1083,6 +1105,12 @@ const steered = []
 const agentD = { session: { header: { cwd: ws, id: 's4' }, events: sevenSteps }, steer: (m) => steered.push(m) }
 stopping({ agent: agentD, turn: 1, signal: new AbortController().signal })
 check('steer after 7 consecutive tool steps', steered.length === 1 && steered[0].content.some((b) => b.type === 'text' && b.text.includes('记忆反思')))
+
+// alpha.4 形态：事件流由 ownEvents() 提供，反射链路必须等价（7 步触发）。
+const steeredA4 = []
+const agentA4 = { session: { header: { cwd: ws, id: 's4a' }, ownEvents: () => sevenSteps }, steer: (m) => steeredA4.push(m) }
+stopping({ agent: agentA4, turn: 1, signal: new AbortController().signal })
+check('alpha.4 ownEvents session steers after 7 consecutive tool steps', steeredA4.length === 1 && steeredA4[0].content.some((b) => b.type === 'text' && b.text.includes('记忆反思')))
 
 // 单步工具调用 → 不触发
 const steered1 = []


### PR DESCRIPTION
## 问题 / Problem

dsh **0.1.2-alpha.4** 重构移除了 `Session.events` 属性，改为 `ownEvents()` 方法（返回剔除 fork 继承前缀的本会话事件，与旧版 `events` 语义等价）。本插件此前 5 处直读 `agent.session.events`，在 alpha.4 上所有会话立即报 `events is not iterable`，插件整体失效（注入 / 反思 / dream 全挂）。直接硬换 `ownEvents()` 则会破坏仍在使用旧版 dsh 的宿主。

真机验证（alpha.4）另发现客户端崩溃：`computeFoldGroups` / `computeInjectionGroups` 无保护读 `snapshot.chat`，宿主快照形状变化（chat 缺失）时抛 `Cannot read properties of undefined (reading 'chat')`，`MemoryFoldDock` 崩溃导致 conversation.composer.dock slot 失效（console 6 errors）。

> dsh 0.1.2-alpha.4 removed the `Session.events` property in favor of an `ownEvents()` method (session-owned events minus the fork-inherited prefix — semantically equivalent). All 5 direct reads of `agent.session.events` throw `events is not iterable` on alpha.4, taking down injection / reflection / dream entirely. Naively swapping to `ownEvents()` would break hosts still on older dsh. Alpha.4 live verification also surfaced a client crash: `computeFoldGroups` / `computeInjectionGroups` read `snapshot.chat` unguarded — when the host snapshot shape drifts (chat missing) it throws `Cannot read properties of undefined (reading 'chat')`, crashing `MemoryFoldDock` and the whole conversation.composer.dock slot (6 console errors).

## 修复 / Fix

### 服务端：`sessionEventsOf()` 双版本事件读取（f48edde）

- 探测 `ownEvents` 函数形态优先（alpha.4 及以后）
- 回退 `events` 数组属性（旧版宿主）
- 两者皆缺返回空数组 —— **fail-closed，绝不抛错**

5 处调用点（pre-step 首轮判定 / `lastTurnEndReason` / `wasDreamTurn` / `scanTurn` / `consecutiveToolSteps`）全部收敛到该函数，双版本宿主行为一致。`createUserMessage` 快照注入（PR #10）在 alpha.4 上经确认可用，无需改动。

### 客户端：折叠入口 fail-closed（90821d9）

`computeFoldGroups` / `computeInjectionGroups` 前置 `snapshot?.chat === undefined → 返回空组`，降级为不折叠、绝不抛错（与官方 issue #2 `turnOf` 同款哲学）。

## 测试 / Verification

- `sessionEventsOf` 三形态单测 ×4（ownEvents 优先 / events 回退 / 双缺 fail-closed / undefined）
- apply 级 ownEvents-only 会话回归 ×2（pre-step 恢复会话命中链路插入快照 / turn-stopping 7 连续工具步触发反思）——与既有 events 形态断言逐条对齐
- 全套绿：主套件 **324 passed**, 0 failed；client-fold 全过；client-dream-icon 24；client-dream-skip 22；smoke 29
- **真机验证（dsh 0.1.2-alpha.4）**：修复前 6 errors → 修复后 0 errors；服务端 pre-step / 命中链路 / 记忆工具全链路正常，无 `events is not iterable`

## 动机 / Motivation

本地在 dsh 0.1.2-alpha.4 上以 fork 形式适配过同一问题；本 PR 是官方仓库可接受的最小姿态——一个兼容函数 + 折叠防护 + 双形态测试，不让旧版宿主回归，也让 alpha.4 宿主直接可用。