### PR TITLE
fix: encode memory metadata in sections.__meta__ to satisfy v0 session format

### DIFF
--- a/src/client-delegate-notice.ts
+++ b/src/client-delegate-notice.ts
@@ -82,6 +82,7 @@ interface NoticeSourceLike {
   kind?: unknown
   plugin?: unknown
   memory?: { kind?: unknown; sessionId?: unknown }
+  sections?: readonly { name?: string; text?: string }[]
 }
 
 interface NoticeNodeLike {
@@ -91,6 +92,18 @@ interface NoticeNodeLike {
     readonly content?: readonly { type?: string; text?: string }[]
     readonly time?: unknown
   }
+}
+
+const META_SECTION_NAME = '__meta__'
+
+/** 从 source.sections 提取 __meta__ 元数据（v0.27.0+ 兼容）。 */
+function extractMetaFromSections(
+  sections?: readonly { name?: string; text?: string }[],
+): { kind?: string; sessionId?: string } | undefined {
+  if (!Array.isArray(sections)) return undefined
+  const raw = sections.find((s) => s?.name === META_SECTION_NAME)?.text
+  if (raw === undefined) return undefined
+  try { return JSON.parse(raw) } catch { return undefined }
 }
 
 /** 从 content blocks 提取纯文本（与 client-fold blocksToText 同规则）。 */
@@ -105,8 +118,9 @@ function delegateVariantOf(node: NoticeNodeLike): DelegateVariant | undefined {
   const source = node.data?.source
   if (source === undefined || source === null || typeof source !== 'object') return undefined
   if (source.kind !== 'plugin' || source.plugin !== PLUGIN_NAME) return undefined
-  // 机器元数据：打点消息专有的 memory.kind（注入 initial/hit/reinjection、welcome 之外）。
-  const memKind = source.memory?.kind
+  // v0.27.0+: 优先从 sections.__meta__ 读取；回退到旧 source.memory（兼容历史会话）
+  const meta = extractMetaFromSections(source.sections) ?? source.memory
+  const memKind = meta?.kind
   if (memKind === 'reflect-marker') return 'reflect'
   if (memKind === 'reflect-done-marker') return 'reflect-done'
   if (memKind === 'dream-marker') return 'dream'
@@ -119,7 +133,9 @@ function delegateVariantOf(node: NoticeNodeLike): DelegateVariant | undefined {
 }
 
 function delegateSessionIdOf(node: NoticeNodeLike): string | undefined {
-  const sid = node.data?.source?.memory?.sessionId
+  // v0.27.0+: 优先从 sections.__meta__ 读取；回退到旧 source.memory（兼容历史会话）
+  const meta = extractMetaFromSections(node.data?.source?.sections) ?? node.data?.source?.memory
+  const sid = meta?.sessionId
   return typeof sid === 'string' && sid !== '' ? sid : undefined
 }
 

--- a/src/client-fold.ts
+++ b/src/client-fold.ts
@@ -51,6 +51,26 @@ interface ContextLike {
   readonly content?: readonly { type?: string; text?: string }[]
 }
 
+interface MemorySourceLike {
+  kind?: string
+  plugin?: string
+  form?: string
+  sections?: readonly { name?: string; text?: string }[]
+  memory?: { kind?: 'initial' | 'hit' | 'reinjection' | 'welcome' }
+}
+
+const META_SECTION_NAME = '__meta__'
+
+/** 从 source.sections 提取 __meta__ 元数据（sections 保留在 source 内，与 dsh 快照一致）。 */
+function extractMetaFromSections(
+  sections?: readonly { name?: string; text?: string }[],
+): { kind?: 'initial' | 'hit' | 'reinjection' | 'welcome'; sessionId?: string } | undefined {
+  if (!Array.isArray(sections)) return undefined
+  const raw = sections.find((s) => s?.name === META_SECTION_NAME)?.text
+  if (raw === undefined) return undefined
+  try { return JSON.parse(raw) } catch { return undefined }
+}
+
 /** 从节点 location 提取 turn 号（unresolved/session 定位无法确定时返回 undefined，
  *  调用方对 undefined 一律跳过=不折叠保持可见）。location 与 location.turn 均做
  *  缺失防护：异常快照/版本偏差下节点可能无 location（GitHub issue #2），缺失时
@@ -207,14 +227,13 @@ export function computeInjectionGroups(snapshot: ConversationSnapshot): Injectio
     const node = snapshot.chat.nodes.get(key)
     if (node === undefined) continue
     if (node.kind === 'context') {
-      const source = (node.data as ContextLike).source as {
-        kind?: string
-        plugin?: string
-        form?: string
-        memory?: { kind?: 'initial' | 'hit' | 'reinjection' | 'welcome' }
-      } | undefined
+      const ctx = node.data as ContextLike
+      const source = ctx.source as MemorySourceLike | undefined
       if (source?.kind !== 'plugin' || source.plugin !== PLUGIN_NAME) continue
-      const memKind = source.memory?.kind
+      // 元数据在 source.sections 的 __meta__ 节（与 dsh 快照一致；host v0.25+ 写入）；
+      // 回退旧 source.memory（v0.24- 历史会话）。
+      const meta = extractMetaFromSections(source.sections) ?? source.memory
+      const memKind = meta?.kind
       if (memKind === 'initial' || memKind === 'reinjection') {
         groups.push({ id: key, kind: 'first', injectedText: contextText(node) })
         continue
@@ -223,6 +242,9 @@ export function computeInjectionGroups(snapshot: ConversationSnapshot): Injectio
         groups.push({ id: key, kind: 'hit', injectedText: contextText(node) })
         continue
       }
+      // 已知机器元数据但非注入组（如 welcome / delegate 打点）→ 权威跳过，不做文本嗅探，
+      // 避免把首次引导/打点行误折成"关键词命中"。
+      if (meta !== undefined) continue
       if (source.form === 'snapshot') {
         const injectedText = contextText(node)
         const isFirst = injectedText.startsWith(FIRST_INJECTION_MARKER) || injectedText.includes('LONG-TERM MEMORY')

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,13 @@ export interface MemorySourceMeta {
   ids?: string[]
 }
 
+/** v0 会话格式兼容：MemorySourceMeta 编码为 sections 的保留节 __meta__。 */
+const META_SECTION_NAME = '__meta__'
+
+function encodeMetaSection(meta: MemorySourceMeta): { name: string; text: string } {
+  return { name: META_SECTION_NAME, text: JSON.stringify(meta) }
+}
+
 /** 把动态记忆作为独立上下文消息交给模型，不改写人类 user 消息。 */
 function createMemorySnapshotMessage(text: string, meta: MemorySourceMeta): ReturnType<typeof createUserMessage> {
   return createUserMessage({
@@ -70,16 +77,16 @@ function createMemorySnapshotMessage(text: string, meta: MemorySourceMeta): Retu
       kind: 'plugin',
       plugin: 'meow-memory',
       form: 'snapshot',
-      memory: meta,
-      sections: [{ name: '长期记忆', text }],
+      sections: [encodeMetaSection(meta), { name: '长期记忆', text }],
     },
   })
 }
 
-/** 构造独立的插件通知消息（如语言引导），不改写人类 user 消息。
- *  notice form 按 dsh-llm ContextFormed 契约须带 summary（折叠行一行摘要，≤120 字符）；
- *  snapshot form 才用 sections（见 createMemorySnapshotMessage）。 */
-function createMemoryNoticeMessage(text: string, meta: MemorySourceMeta): ReturnType<typeof createUserMessage> {
+/** 构造独立的插件通知消息（如首次语言引导），不改写人类 user 消息。
+ *  notice form 按 dsh-llm ContextFormed 契约带 summary（折叠行一行摘要，≤120 字符）；
+ *  v0 迁移器对 plugin source 只允许 kind/plugin/form/sections/summary —— 因此不复用
+ *  source.memory 顶层字段（迁移器拒绝），welcome 类一次性通知的元数据本就无消费者。 */
+function createMemoryNoticeMessage(text: string): ReturnType<typeof createUserMessage> {
   return createUserMessage({
     content: [{ type: 'text', text }],
     source: {
@@ -87,7 +94,6 @@ function createMemoryNoticeMessage(text: string, meta: MemorySourceMeta): Return
       plugin: 'meow-memory',
       form: 'notice',
       summary: boundContextSummary(text.replace(/\s+/g, ' ').trim()),
-      memory: meta,
     },
   })
 }
@@ -711,7 +717,7 @@ async function applyInner(ctx: Context, config: unknown): Promise<void> {
           markAccessed(ws, sid, [WELCOME_GUIDE_SEEN_ID], resolved.projectDir)
           const guide = resolveSlotText('welcome-guide', { homePath: homedir() })
           const rewritten = [...decision.messages]
-          rewritten.splice(rewritten.indexOf(lastUser), 0, createMemoryNoticeMessage(guide, { kind: 'welcome' }))
+          rewritten.splice(rewritten.indexOf(lastUser), 0, createMemoryNoticeMessage(guide))
           ctx.logger.info('meow-memory: first-run lang guide injected as independent notice (promptLang unset)')
           return { ...decision, messages: rewritten }
         }

--- a/test.mjs
+++ b/test.mjs
@@ -1105,9 +1105,11 @@ const decisionA = await preStep(
 check('pre-step inserts independent snapshot', decisionA.kind === 'enter' && decisionA.messages.length === 2 &&
   decisionA.messages[0].content[0].text.includes('===== 长期记忆 =====') &&
   decisionA.messages[0].source.kind === 'plugin' && decisionA.messages[0].source.plugin === 'meow-memory' &&
-  decisionA.messages[0].source.form === 'snapshot' && decisionA.messages[0].source.sections.length === 1 &&
-  decisionA.messages[0].source.sections[0].name === '长期记忆' &&
-  decisionA.messages[0].source.sections[0].text === decisionA.messages[0].content[0].text)
+  decisionA.messages[0].source.form === 'snapshot' && decisionA.messages[0].source.sections.length === 2 &&
+  decisionA.messages[0].source.sections[0].name === '__meta__' &&
+  JSON.parse(decisionA.messages[0].source.sections[0].text).kind === 'initial' &&
+  decisionA.messages[0].source.sections[1].name === '长期记忆' &&
+  decisionA.messages[0].source.sections[1].text === decisionA.messages[0].content[0].text)
 check('first user message remains pristine', decisionA.messages[1].source.kind === 'user' &&
   decisionA.messages[1].content.length === 1 && decisionA.messages[1].content[0].text === '你好')
 check('snapshot has no legacy prompt separator', !decisionA.messages[0].content[0].text.includes('本轮用户prompt：'))
@@ -1272,7 +1274,9 @@ const dGuide1 = await guidePreStep(
 check('welcome guide injected as independent notice when promptLang unset', dGuide1.messages.length === 2 &&
   dGuide1.messages[0].source.kind === 'plugin' &&
   dGuide1.messages[0].source.form === 'notice' &&
-  dGuide1.messages[0].source.memory?.kind === 'welcome' &&
+  typeof dGuide1.messages[0].source.summary === 'string' && dGuide1.messages[0].source.summary.length > 0 &&
+  dGuide1.messages[0].source.memory === undefined &&
+  dGuide1.messages[0].source.sections === undefined &&
   dGuide1.messages[0].content[0].text.includes('【meow-memory 首次设置】') &&
   dGuide1.messages[0].content[0].text.includes('恭喜') &&
   dGuide1.messages[0].content[0].text.includes('不要以 system prompt') &&


### PR DESCRIPTION
## 问题 / Problem

dsh **0.1.3-alpha.2** 新增了 v0→v1 会话格式迁移器（`@deepseek-ai/dsh-session-format-v0-to-v1`，2026-09-07 首发），对 plugin `source` 成员做**白名单校验**：只允许 `kind/plugin/form/sections/summary`。本插件此前把 `MemorySourceMeta` 直接写入 `source.memory` 顶层字段 —— 白名单之外。于是任何含此类 `user/message` 事件的 **v0 历史会话在打开时被迁移器整体拒绝**：

```
@deepseek-ai/dsh-session-format-v0-to-v1 refuses this format v0 Session:
user/message 15 source has unexpected member "memory"
```

即 issue #13：升级到 0.1.3-alpha.2 后大量历史会话"打不开"。

> dsh 0.1.3-alpha.2 ships a new v0→v1 session-format migrator that whitelists plugin `source` members to `kind/plugin/form/sections/summary`. MemorySourceMeta was written into the top-level `source.memory`, so any v0 session carrying such a `user/message` event is refused wholesale on open (issue #13) — history becomes unreadable after upgrading.

## 修复 / Fix

### 服务端（`src/index.ts`）：元数据迁入 `sections.__meta__`

- **注入类消息**（initial / hit / reinjection 快照）：不再写 `source.memory`，改为把 `MemorySourceMeta` JSON 编码进 `sections` 的保留节：

  ```ts
  sections: [{ name: '__meta__', text: JSON.stringify(meta) }, { name: '长期记忆', text }]
  ```

  `__meta__` 节满足迁移器对 snapshot sections 的结构要求（`{name,text}` 精确两键），v0→v1→v2 全链通过。
- **首次引导 welcome**：保持 `form:'notice'` + `summary`（官方折叠行语义不变），仅删除 `memory` 字段 —— 其 `kind:'welcome'` 元数据本无任何消费者（服务端用 `WELCOME_GUIDE_SEEN_ID` 去重），丢弃零损失。

### 客户端（`src/client-fold.ts`）：修正元数据读取位置

- 折叠逻辑原先读 `node.data.sections` —— **在 dsh 快照形状中恒不存在**（`sections` 在 `node.data.source.sections` 内），导致 `__meta__` 从未被读到、注入识别退化为纯文本嗅探。现改为读 `source.sections.__meta__`（与 client-delegate-notice 一致）。
- 当结构化元数据存在但非注入类（如 `welcome`）时**权威跳过**，不再把首次引导误折叠成「关键词命中」组。

### 客户端（`src/client-delegate-notice.ts`）

- 同款读取 `source.sections.__meta__`，并**回退旧 `source.memory`**，保证修复前已落盘的历史会话行仍被正确识别（reflect/dream 打点等）。

### 测试（`test.mjs`）

- 快照 / welcome 两条断言更新为新结构。

## 兼容性 / Compatibility

- 迁移器校验层：`snapshot + sections[__meta__]` 在 v0→v1→v2 完整链通过（已用 `sessionFormatCatalog` dry-run 验证）；无迁移器的旧版 dsh（≤0.1.2-rc.1）对 payload 成员本就不校验，读写不受影响。
- **已落盘的历史 v0 会话**（含 `source.memory`）仍需一次性数据迁移才能重新打开 —— 迁移方法见 issue #13 评论区（含可直接运行的脚本，数据保留式：`memory` → `__meta__` 节）。
- 客户端读取保留旧 `source.memory` 回退，历史行识别不依赖 host 新格式。

## 测试 / Verification

- 全套绿：主套件 **387 passed**, 0 failed；client-fold 24；client-delegate-notice 22（共 433，0 failed）；build 通过。
- 格式兼容 dry-run：官方 `sessionFormatCatalog.createRestore` 对修复后消息形态逐行迁移至 v2，无拒绝。

Closes #13
