### PR TITLE
fix(dream): 解包 agents.resume() 返回的 handle——自动 dream 在重启后从不触发

### DIFF
--- a/src/dream.ts
+++ b/src/dream.ts
@@ -734,13 +734,15 @@ export async function resumeAndDream(ctx: Context, sessionId: string, workspace:
       log(`check agent-resume-unavailable sid=${sid} service=${agentsSvc ? 'yes' : 'no'}`)
       return
     }
-    const agent = await agentsSvc.resume({ resumeSessionId: sessionId })
+    const resumed = await agentsSvc.resume({ resumeSessionId: sessionId })
+    // dsh 的 agents.resume() 返回 handle { agent, dispose }，不是 agent 本身
+    const agent = (resumed as { agent?: unknown })?.agent ?? resumed
     const header = (agent as { session?: { header?: { id?: unknown; origin?: unknown; delegationDepth?: unknown } } })
       ?.session?.header
     if (header === undefined || header === null || typeof header.id !== 'string' || header.id.length === 0) {
       // resume resolve 但 agent 无可用 header——实测=子代理会话（dsh 对 fork 子代理的
-      // resume 返回不可用句柄；主会话 resume 恒返回完整 agent，e95f149b 真机实证
-      // 2026-09-05）。标缓存：后续周期 sweep 直接跳过，不再反复 resume。
+      // resume 返回不可用句柄）。注意主会话返回的同样是 handle，已在上面解包 .agent，
+      // 解包后仍无 header 才落到这里。标缓存：后续周期 sweep 直接跳过，不再反复 resume。
       autoDreamSkipWindows.add(sessionId)
       log(`check resume unusable-agent sid=${sid} -> skip`)
       return


### PR DESCRIPTION
Fixes #17

## 改动

`src/dream.ts` 的 `resumeAndDream`：`agents.resume()` 返回的是 handle `{ agent, dispose }`，不是 agent 本身，需解包 `.agent`。

~~~diff
-    const agent = await agentsSvc.resume({ resumeSessionId: sessionId })
+    const resumed = await agentsSvc.resume({ resumeSessionId: sessionId })
+    // dsh 的 agents.resume() 返回 handle { agent, dispose }，不是 agent 本身
+    const agent = (resumed as { agent?: unknown })?.agent ?? resumed
~~~

## 说明

- `?? resumed` 兼容旧版宿主直接返回 agent 的情形，旧宿主行为逐字节不变；
- 顺带修正紧随其后的注释——原注释称「主会话 resume 恒返回完整 agent」，实测相反：主会话返回的同样是 handle，于是恒判 `unusable-agent`；
- 只改 TS 源码，不动构建产物。

## 验证

本机（DSH Desktop 2.0.9 / 内核 0.1.5-rc.1 / meow-memory 0.26.0 / Node 24.19.0）已打等价补丁；重启后以 `dream-debug.log` 中 `agent-resumed` 计数是否由 0 转正来验证。详细现象与实测数据见 #17。